### PR TITLE
Browse d/copyright files

### DIFF
--- a/debsources/app/copyright/routes.py
+++ b/debsources/app/copyright/routes.py
@@ -16,9 +16,9 @@ from flask import jsonify
 
 from ..helper import bind_render
 from . import bp_copyright
-from ..views import (PrefixView, ListPackagesView, ErrorHandler, Ping,
-                     PackageVersionsView)
-from .views import IndexView, LicenseView
+from ..views import (IndexView, PrefixView, ListPackagesView, ErrorHandler,
+                     Ping, PackageVersionsView)
+from .views import LicenseView
 
 
 # context vars
@@ -35,10 +35,14 @@ bp_copyright.errorhandler(404)(
     lambda e: (ErrorHandler()(e, http=404), 404))
 
 
+# INDEXVIEW
 bp_copyright.add_url_rule(
     '/',
     view_func=IndexView.as_view(
-        'index'))
+        'index',
+        render_func=bind_render('copyright/index.html'),
+        err_func=ErrorHandler('copyright'),
+        news_html='copyright_news.html'))
 
 # ping service
 bp_copyright.add_url_rule(

--- a/debsources/app/copyright/routes.py
+++ b/debsources/app/copyright/routes.py
@@ -11,12 +11,99 @@
 
 from __future__ import absolute_import
 
-from . import bp_copyright
 
-from .views import IndexView
+from flask import jsonify
+
+from ..helper import bind_render
+from . import bp_copyright
+from ..views import (PrefixView, ListPackagesView, ErrorHandler, Ping,
+                     PackageVersionsView)
+from .views import IndexView, LicenseView
+
+
+# context vars
+@bp_copyright.context_processor
+def skeleton_variables():
+    site_name = bp_copyright.name
+    return dict(site_name=site_name,)
+
+
+# 403 and 404 errors
+bp_copyright.errorhandler(403)(
+    lambda e: (ErrorHandler()(e, http=403), 403))
+bp_copyright.errorhandler(404)(
+    lambda e: (ErrorHandler()(e, http=404), 404))
 
 
 bp_copyright.add_url_rule(
     '/',
     view_func=IndexView.as_view(
         'index'))
+
+# ping service
+bp_copyright.add_url_rule(
+    '/api/ping/',
+    view_func=Ping.as_view(
+        'ping',))
+
+
+# PREFIXVIEW
+bp_copyright.add_url_rule(
+    '/prefix/<prefix>/',
+    view_func=PrefixView.as_view(
+        'prefix',
+        render_func=bind_render('prefix.html'),
+        err_func=ErrorHandler('copyright'),))
+
+
+# api
+bp_copyright.add_url_rule(
+    '/api/prefix/<prefix>/',
+    view_func=PrefixView.as_view(
+        'api_prefix',
+        render_func=jsonify,
+        err_func=ErrorHandler(mode='json')))
+
+
+# LISTPACKAGESVIEW
+bp_copyright.add_url_rule(
+    '/list/<int:page>/',
+    view_func=ListPackagesView.as_view(
+        'list_packages',
+        render_func=bind_render('list.html'),
+        err_func=ErrorHandler('copyright'),
+        pagination=True))
+
+
+# api
+bp_copyright.add_url_rule(
+    '/api/list/',
+    view_func=ListPackagesView.as_view(
+        'api_list_packages',
+        render_func=jsonify,
+        err_func=ErrorHandler(mode='json')))
+
+
+# VERSIONSVIEW
+bp_copyright.add_url_rule(
+    '/cp/<string:packagename>/',
+    view_func=PackageVersionsView.as_view(
+        'versions',
+        render_func=bind_render('copyright/package.html'),
+        err_func=ErrorHandler('copyright')))
+
+# api
+bp_copyright.add_url_rule(
+    '/api/cp/<string:packagename>/',
+    view_func=PackageVersionsView.as_view(
+        'api_cp_versions',
+        render_func=jsonify,
+        err_func=ErrorHandler(mode='json')))
+
+# LICENSEVIEW
+bp_copyright.add_url_rule(
+    '/cp/<path:path_to>/',
+    view_func=LicenseView.as_view(
+        'license',
+        render_func=bind_render('copyright/license.html'),
+        err_func=ErrorHandler('copyright')))

--- a/debsources/app/copyright/templates/copyright/404_suggestions.html
+++ b/debsources/app/copyright/templates/copyright/404_suggestions.html
@@ -7,11 +7,11 @@
 
 <p>The specific version of the package you requested doesn't exist,
 but other versions of this package are available in the database.
-The file you are looking for might exist in one of the following
+The license you are looking for might exist in one of the following
 versions:
 <ul>
 {% for s in suggestions %}
-  <li><a href="{{ url_for('.source', path_to=s) }}">{{ s }}</a></li>
+  <li><a href="{{ url_for('.license', path_to=s) }}">{{ s }}</a></li>
 {% endfor %}
 </ul>
 </p>

--- a/debsources/app/copyright/templates/copyright/index.html
+++ b/debsources/app/copyright/templates/copyright/index.html
@@ -1,0 +1,59 @@
+{#
+  Copyright (C) 2013  The Debsources developers <info@sources.debian.net>.
+  See the AUTHORS file at the top-level directory of this distribution and at
+  https://anonscm.debian.org/gitweb/?p=qa/debsources.git;a=blob;f=AUTHORS;hb=HEAD
+  License: GNU Affero General Public License, version 3 or above.
+#}
+{# copied from templates/index.html #}
+{% extends name+"/base.html" %}
+
+{% block title %}Debian Sources{% endblock %}
+
+{% block breadcrumbs %}{% endblock %}
+
+{% block content %}
+
+<div id="indexmenu">
+
+<h1 class="h1mainpage">{{ self.title() }}</h1>
+<h3><em>All Debian license are belong to us</em> &emsp;
+  <small>&mdash; Anonymous</small>
+  <sup><a href="https://en.wikipedia.org/wiki/All_your_base_are_belong_to_us"><span style="font-family: monospace; color: black;">[^]</span></a></sup>
+</h3>
+<p>Browse through the licenses of the
+  <a href="https://www.debian.org">Debian</a> operating system.
+  <a href="{{ url_for(name+'.doc_overview') }}">Read more…</a></p>
+<table>
+  <tr>
+    <td id="browse">
+      <p><strong>Browse</strong> by prefix</p>
+      <p>{{ macros.render_packages_prefixes(packages_prefixes) }}</p>
+    </td>
+    <!--
+    <td id="search">
+      <p><strong>Search</strong></p>
+      <ul style="list-style-type: none">
+  <li>by <em>package name</em>:<br />
+	  {{ macros.searchform(searchform, value=query, display="inline", size="25", autofocus=True, id="query-2") }}
+	</li>
+      </ul>
+    </td>-->
+  </tr>
+</table>
+
+</div>
+
+{% if news -%}
+<h3><a name="news">News</a></h3>
+{{ news|safe }}
+{% endif %}
+
+{% endblock %}
+
+{# show the background debian image #}
+{% block bg_wrapper %}
+<div id="bg-wrapper" style="background-image: url('{{ url_for('static', filename='img/debsources.png') }}');">
+  <div id="content">{{ self.content() }}</div>
+  <footer id="footer">{{ self.footer() }}</footer>
+</div>
+{% endblock %}

--- a/debsources/app/copyright/templates/copyright/license.html
+++ b/debsources/app/copyright/templates/copyright/license.html
@@ -4,17 +4,19 @@
   https://anonscm.debian.org/gitweb/?p=qa/debsources.git;a=blob;f=AUTHORS;hb=HEAD
   License: GNU Affero General Public License, version 3 or above.
 #}
-{# copied from templates/prefix.html #}
-{% extends "sources/base.html" %}
+{# copied from templates/source_base.html #}
+{% extends name+"/base.html" %}
 
-{% block title %}Package list: prefix {{ prefix }}{% endblock %}
+{% block head %}
+{{ super() }}
+<link rel="stylesheet" type="text/css"
+      href="{{ url_for('sources.static', filename='css/source_folder.css') }}" />
+{% endblock %}
 
-{% block breadcrumbs %}packages by prefix / {{ prefix }}{% endblock %}
-
+{% block title %}Package: {{ package }}{% endblock %}
 {% block content %}
-
 <h2>{{ self.title() }}</h2>
-{{ macros.show_suite(suite) }}
-{{ macros.listpackages(packages, suite) }}
+
+<p>License for {{package}} / {{version}}</p>
 
 {% endblock %}

--- a/debsources/app/copyright/templates/copyright/package.html
+++ b/debsources/app/copyright/templates/copyright/package.html
@@ -1,0 +1,23 @@
+{#
+  Copyright (C) 2013  The Debsources developers <info@sources.debian.net>.
+  See the AUTHORS file at the top-level directory of this distribution and at
+  https://anonscm.debian.org/gitweb/?p=qa/debsources.git;a=blob;f=AUTHORS;hb=HEAD
+  License: GNU Affero General Public License, version 3 or above.
+#}
+{# copied from templates/source_base.html #}
+{% extends name+"/source_base.html" %}
+
+{% block head %}
+{{ super() }}
+<link rel="stylesheet" type="text/css"
+      href="{{ url_for('sources.static', filename='css/source_folder.css') }}" />
+{% endblock %}
+
+{% block title %}Package: {{ package }}{% endblock %}
+{% block source_content %}
+<h2>{{ self.title() }}</h2>
+{{ macros.show_suite(suite) }}
+
+{{ macros.show_versions(versions, path, 'sources.source')}}
+
+{% endblock %}

--- a/debsources/app/copyright/templates/copyright/package.html
+++ b/debsources/app/copyright/templates/copyright/package.html
@@ -18,6 +18,6 @@
 <h2>{{ self.title() }}</h2>
 {{ macros.show_suite(suite) }}
 
-{{ macros.show_versions(versions, path, 'sources.source')}}
+{{ macros.show_versions(versions, path, '.license')}}
 
 {% endblock %}

--- a/debsources/app/copyright/views.py
+++ b/debsources/app/copyright/views.py
@@ -13,9 +13,23 @@ from __future__ import absolute_import
 
 from flask.views import View
 
+from ..views import GeneralView
+
 
 # this is just a placeholder
 class IndexView(View):
 
     def dispatch_request(self):
         return "Hello World"
+
+
+class LicenseView(GeneralView):
+
+    def get_objects(self, path_to):
+        path_dict = path_to.split('/')
+
+        package = path_dict[0]
+        version = path_dict[1]
+
+        return dict(package=package,
+                    version=version)

--- a/debsources/app/sources/routes.py
+++ b/debsources/app/sources/routes.py
@@ -34,9 +34,9 @@ def skeleton_variables():
 # XXX 500 handler cannot be registered on a blueprint
 # TODO see debsources.app.view#errorhandler section
 bp_sources.errorhandler(403)(
-    lambda e: (ErrorHandler(bp_name='sources')(e, http=403), 403))
+    lambda e: (ErrorHandler()(e, http=403), 403))
 bp_sources.errorhandler(404)(
-    lambda e: (ErrorHandler(bp_name='sources')(e, http=404), 404))
+    lambda e: (ErrorHandler()(e, http=404), 404))
 
 
 # ping service
@@ -227,7 +227,7 @@ bp_sources.add_url_rule(
     '/prefix/<prefix>/',
     view_func=PrefixView.as_view(
         'prefix',
-        render_func=bind_render('sources/prefix.html'),
+        render_func=bind_render('prefix.html'),
         err_func=ErrorHandler('sources'),))
 
 
@@ -245,7 +245,7 @@ bp_sources.add_url_rule(
     '/list/<int:page>/',
     view_func=ListPackagesView.as_view(
         'list_packages',
-        render_func=bind_render('sources/list.html'),
+        render_func=bind_render('list.html'),
         err_func=ErrorHandler('sources'),
         pagination=True))
 

--- a/debsources/app/sources/templates/sources/base.html
+++ b/debsources/app/sources/templates/sources/base.html
@@ -11,10 +11,10 @@
 
 {% block nav %}
   <ul>
-    <li><a href="{{ url_for('.index') }}">Home</a></li>
-    <li><a href="{{ url_for('.advanced_search') }}">Search</a></li>
-    <li><a href="{{ url_for('.doc') }}">Documentation</a></li>
-    <li><a href="{{ url_for('.stats') }}">Stats</a></li>
-    <li><a href="{{ url_for('.about') }}">About</a></li>
+    <li><a href="{{ url_for('sources.index') }}">Home</a></li>
+    <li><a href="{{ url_for('sources.advanced_search') }}">Search</a></li>
+    <li><a href="{{ url_for('sources.doc') }}">Documentation</a></li>
+    <li><a href="{{ url_for('sources.stats') }}">Stats</a></li>
+    <li><a href="{{ url_for('sources.about') }}">About</a></li>
   </ul>
 {% endblock %}

--- a/debsources/app/templates/403.html
+++ b/debsources/app/templates/403.html
@@ -4,14 +4,15 @@
   https://anonscm.debian.org/gitweb/?p=qa/debsources.git;a=blob;f=AUTHORS;hb=HEAD
   License: GNU Affero General Public License, version 3 or above.
 #}
-{# copied from templates/500.html #}
-{% extends "sources/base.html" %}
+{# copied from templates/403.html #}
 
-{% block title %}500{% endblock %}
+{% extends name+"/base.html" %}
+
+{% block title %}403{% endblock %}
 {% block content %}
 
 <h2>{{ self.title() }}</h2>
-<p>Something went wrong.</p>
+<p>Permission denied.</p>
 <a href="/">Go home</a>
 
 {% endblock %}

--- a/debsources/app/templates/404.html
+++ b/debsources/app/templates/404.html
@@ -5,7 +5,7 @@
   License: GNU Affero General Public License, version 3 or above.
 #}
 {# copied from templates/404.html #}
-{% extends "sources/base.html" %}
+{% extends name+"/base.html" %}
 
 {% block title %}404{% endblock %}
 {% block content %}

--- a/debsources/app/templates/404_suggestions.html
+++ b/debsources/app/templates/404_suggestions.html
@@ -1,0 +1,17 @@
+{#
+  Copyright (C) 2013  The Debsources developers <info@sources.debian.net>.
+  See the AUTHORS file at the top-level directory of this distribution and at
+  https://anonscm.debian.org/gitweb/?p=qa/debsources.git;a=blob;f=AUTHORS;hb=HEAD
+  License: GNU Affero General Public License, version 3 or above.
+#}
+{# copied from templates/404_suggestions.html #}
+{% extends name+"/base.html" %}
+
+{% block title %}404{% endblock %}
+{% block content %}
+<h2>{{ self.title() }}</h2>
+{% include site_name+"/404_suggestions.html" %}
+ 
+<a href="/">Go home</a>
+
+{% endblock %}

--- a/debsources/app/templates/500.html
+++ b/debsources/app/templates/500.html
@@ -1,0 +1,17 @@
+{#
+  Copyright (C) 2013  The Debsources developers <info@sources.debian.net>.
+  See the AUTHORS file at the top-level directory of this distribution and at
+  https://anonscm.debian.org/gitweb/?p=qa/debsources.git;a=blob;f=AUTHORS;hb=HEAD
+  License: GNU Affero General Public License, version 3 or above.
+#}
+{# copied from templates/500.html #}
+{% extends name+"/base.html" %}
+
+{% block title %}500{% endblock %}
+{% block content %}
+
+<h2>{{ self.title() }}</h2>
+<p>Something went wrong.</p>
+<a href="/">Go home</a>
+
+{% endblock %}

--- a/debsources/app/templates/_macros.html
+++ b/debsources/app/templates/_macros.html
@@ -33,7 +33,7 @@ https://pythonhosted.org/Flask-SQLAlchemy/api.html#flask.ext.sqlalchemy.Paginati
 {%- endmacro %}
 
 {% macro searchform(form, display="block") -%}
-  <form action="{{ url_for('.recv_search') }}" name="searchform"
+  <form action="{{ url_for('sources.recv_search') }}" name="searchform"
         method="post" style="display: {{ display }};">
       {{ form.query(**kwargs) }}
     {% for error in form.errors.query %}

--- a/debsources/app/templates/base.html
+++ b/debsources/app/templates/base.html
@@ -59,7 +59,7 @@
 
       <footer id="footer">
         {% block footer %}
-          {% include site_name+"/footer.inc.html" %}
+          {% include name+"/footer.inc.html" %}
         {% endblock %}
       </footer>
     {% endblock %}

--- a/debsources/app/templates/list.html
+++ b/debsources/app/templates/list.html
@@ -4,15 +4,20 @@
   https://anonscm.debian.org/gitweb/?p=qa/debsources.git;a=blob;f=AUTHORS;hb=HEAD
   License: GNU Affero General Public License, version 3 or above.
 #}
-{# copied from templates/403.html #}
 
-{% extends "sources/base.html" %}
+{# copied from templates/list.html #}
+{% extends name+"/base.html" %}
 
-{% block title %}403{% endblock %}
+{% block title %}Package list: page {{ page }}{% endblock %}
+
+{% block breadcrumbs %}packages list / {{ page }}{% endblock %}
+
 {% block content %}
 
 <h2>{{ self.title() }}</h2>
-<p>Permission denied.</p>
-<a href="/">Go home</a>
+
+{{ macros.listpackages(packages) }}
+
+{{ macros.render_pagination(pagination) }}
 
 {% endblock %}

--- a/debsources/app/templates/prefix.html
+++ b/debsources/app/templates/prefix.html
@@ -4,20 +4,17 @@
   https://anonscm.debian.org/gitweb/?p=qa/debsources.git;a=blob;f=AUTHORS;hb=HEAD
   License: GNU Affero General Public License, version 3 or above.
 #}
+{# copied from templates/prefix.html #}
+{% extends name+"/base.html" %}
 
-{# copied from templates/list.html #}
-{% extends "sources/base.html" %}
+{% block title %}Package list: prefix {{ prefix }}{% endblock %}
 
-{% block title %}Package list: page {{ page }}{% endblock %}
-
-{% block breadcrumbs %}packages list / {{ page }}{% endblock %}
+{% block breadcrumbs %}packages by prefix / {{ prefix }}{% endblock %}
 
 {% block content %}
 
 <h2>{{ self.title() }}</h2>
-
-{{ macros.listpackages(packages) }}
-
-{{ macros.render_pagination(pagination) }}
+{{ macros.show_suite(suite) }}
+{{ macros.listpackages(packages, suite) }}
 
 {% endblock %}

--- a/debsources/app/views.py
+++ b/debsources/app/views.py
@@ -88,8 +88,7 @@ app.jinja_env.globals['url_for_other_page'] = url_for_other_page
 # ERRORS
 class ErrorHandler(object):
 
-    def __init__(self, bp_name='', mode='html', http=404):
-        self.bp_name = bp_name
+    def __init__(self, mode='html', http=404):
         self.mode = mode
         self.http = http
 
@@ -102,14 +101,11 @@ class ErrorHandler(object):
             raise Exception("Unimplemented HTTP error: {}".format(self.http))
         return method(error)
 
-    def bp_path(self, tpl):
-        return os.path.join(self.bp_name, tpl)
-
     def error_403(self, error):
         if self.mode == 'json':
             return jsonify(dict(error=403))
         else:
-            return render_template(self.bp_path('403.html')), 403
+            return render_template('403.html'), 403
 
     def error_404(self, error):
         if self.mode == 'json':
@@ -124,10 +120,10 @@ class ErrorHandler(object):
                     [_f for _f in [error.package, v.version, error.path]
                      if _f])
                     for v in possible_versions]
-                return render_template(self.bp_path('404_suggestions.html'),
+                return render_template('404_suggestions.html',
                                        suggestions=suggestions), 404
             else:
-                return render_template(self.bp_path('404.html')), 404
+                return render_template('404.html'), 404
 
     def error_500(self, error):
         """
@@ -138,8 +134,7 @@ class ErrorHandler(object):
         if self.mode == 'json':
             return jsonify(dict(error=500))
         else:
-            return render_template(
-                self.bp_path('500.html')), 500
+            return render_template('500.html'), 500
 
 
 # TODO unlike 403,404, which could be registered per blueprint,
@@ -147,7 +142,7 @@ class ErrorHandler(object):
 # thus, the 500 handler should be aware of the active blueprint,
 # so that correct page template will be rendered for the blueprint.
 # we should avoid hard-coding the 'source'
-app.errorhandler(500)(ErrorHandler('sources', http=500))
+app.errorhandler(500)(ErrorHandler(http=500))
 
 # following is a plain text, bp-agnostic one.
 # app.errorhandler(403)(lambda _: ("Forbidden", 403))

--- a/debsources/app/views.py
+++ b/debsources/app/views.py
@@ -76,7 +76,8 @@ def skeleton_variables():
     return dict(packages_prefixes=packages_prefixes,
                 searchform=SearchForm(),
                 last_update=last_update,
-                credits=credits)
+                credits=credits,
+                name=app.import_name)
 
 
 # jinja2 settings

--- a/debsources/app/views.py
+++ b/debsources/app/views.py
@@ -483,7 +483,12 @@ class PackageVersionsView(GeneralView):
             raise Http404Error("%s not found" % packagename)
 
         # we simply add pathl (for use with "You are here:")
-        pathl = qry.location_get_path_links('.source', packagename)
+        if request.blueprint == 'sources':
+            endpoint = '.source'
+        elif request.blueprint == 'copyright':
+            endpoint = '.license'
+
+        pathl = qry.location_get_path_links(endpoint, packagename)
 
         return dict(type="package",
                     package=packagename,

--- a/debsources/tests/test_webapp.py
+++ b/debsources/tests/test_webapp.py
@@ -78,6 +78,10 @@ class DebsourcesTestCase(unittest.TestCase, DbTestFixture):
         self.assertEqual(rv["status"], "ok")
         self.assertEqual(rv["http_status_code"], 200)
 
+        rv = json.loads(self.app.get('/copyright/api/ping/').data)
+        self.assertEqual(rv["status"], "ok")
+        self.assertEqual(rv["http_status_code"], 200)
+
     def test_api_package_search(self):
         # test exact search result
         rv = json.loads(self.app.get('/api/search/gnubg/').data)
@@ -172,6 +176,12 @@ class DebsourcesTestCase(unittest.TestCase, DbTestFixture):
         self.assertIn({'name': "libcaca"}, rv['packages'])
         self.assertEqual(len(rv['packages']), 18)
 
+        # copyright BP
+        rv = json.loads(
+            self.app.get('/copyright/api/list/').data)
+        self.assertIn({'name': "ocaml-curses"}, rv['packages'])
+        self.assertEqual(len(rv['packages']), 18)
+
     def test_api_by_prefix(self):
         rv = json.loads(self.app.get('/api/prefix/libc/').data)
         self.assertIn({'name': "libcaca"}, rv['packages'])
@@ -180,10 +190,27 @@ class DebsourcesTestCase(unittest.TestCase, DbTestFixture):
         self.assertIn({'name': "libcaca"}, rv['packages'])
         # a non-existing suite specified
         rv = json.loads(
-            self.app.get('/api/prefix/libc/?suite=non-exsiting').data)
+            self.app.get('/api/prefix/libc/?suite=non-existing').data)
         self.assertEqual([], rv['packages'])
         # special suite name "all" is specified
         rv = json.loads(self.app.get('/api/prefix/libc/?suite=all').data)
+        self.assertIn({'name': "libcaca"}, rv['packages'])
+
+        # copyright BP
+        rv = json.loads(
+            self.app.get('/copyright/api/prefix/o/').data)
+        self.assertIn({'name': "ocaml-curses"}, rv['packages'])
+        # suite specified
+        rv = json.loads(
+            self.app.get('/copyright/api/prefix/o/?suite=wheezy').data)
+        self.assertIn({'name': "ocaml-curses"}, rv['packages'])
+        # a non-existing suite specified
+        rv = json.loads(self.app.get(
+            '/copyright/api/prefix/libc/?suite=non-existing').data)
+        self.assertEqual([], rv['packages'])
+        # special suite name "all" is specified
+        rv = json.loads(
+            self.app.get('/copyright/api/prefix/libc/?suite=all').data)
         self.assertIn({'name': "libcaca"}, rv['packages'])
 
     def test_by_prefix(self):
@@ -193,11 +220,26 @@ class DebsourcesTestCase(unittest.TestCase, DbTestFixture):
         rv = self.app.get('/prefix/libc/?suite=squeeze')
         self.assertIn("/src/libcaca", rv.data)
         # a non-existing suite specified
-        rv = self.app.get('/prefix/libc/?suite=non-exsiting')
+        rv = self.app.get('/prefix/libc/?suite=non-existing')
         self.assertNotIn("/src/libcaca", rv.data)
         # special suite name "all" is specified
         rv = self.app.get('/prefix/libc/?suite=all')
         self.assertIn("/src/libcaca", rv.data)
+
+        # copyright BP
+        rv = self.app.get('/copyright/prefix/libc/')
+        self.assertIn("/cp/libcaca", rv.data)
+        # suite specified
+        rv = self.app.get('/copyright/prefix/libc/?suite=squeeze')
+        self.assertIn("/cp/libcaca", rv.data)
+        # a non-existing suite specified
+        rv = self.app.get(
+            '/copyright/prefix/libc/?suite=non-existing')
+        self.assertNotIn("/cp/libcaca", rv.data)
+        # special suite name "all" is specified
+        rv = self.app.get(
+            '/copyright/prefix/libc/?suite=all')
+        self.assertIn("/cp/libcaca", rv.data)
 
     def test_api_case_insensitive_prefix(self):
         rv_lower_case = json.loads(self.app.get('/api/prefix/g/').data)


### PR DESCRIPTION
Using the nav code from PR#4 this PR implements the browsing for d/copyright files.
Included in this branch:
- index view for the /copyright
- browsing by prefix
- browsing by list
- view versions for package
- api functions
- 404, 403, 500 error pages based on the sources BP
