### PR TITLE
API file by file

### DIFF
--- a/debsources/app/copyright/license_helper.py
+++ b/debsources/app/copyright/license_helper.py
@@ -1,0 +1,87 @@
+# Copyright (C) 2015  The Debsources developers <info@sources.debian.net>.
+# See the AUTHORS file at the top-level directory of this distribution and at
+# https://anonscm.debian.org/gitweb/?p=qa/debsources.git;a=blob;f=AUTHORS;hb=HEAD
+#
+# This file is part of Debsources. Debsources is free software: you can
+# redistribute it and/or modify it under the terms of the GNU Affero General
+# Public License as published by the Free Software Foundation, either version 3
+# of the License, or (at your option) any later version.  For more information
+# see the COPYING file at the top-level directory of this distribution and at
+# https://anonscm.debian.org/gitweb/?p=qa/debsources.git;a=blob;f=COPYING;hb=HEAD
+from __future__ import absolute_import
+import io
+
+from flask import current_app, url_for
+from debian import copyright
+
+from debsources.navigation import Location, SourceFile
+from debsources.excepts import (Http404ErrorSuggestions, FileOrFolderNotFound,
+                                InvalidPackageOrVersionError)
+
+
+def get_sources_path(session, package, version, config):
+    ''' Creates a sources_path. Returns exception when it arises
+    '''
+    try:
+        location = Location(session,
+                            config["SOURCES_DIR"],
+                            config["SOURCES_STATIC"],
+                            package, version, 'debian/copyright')
+    except (FileOrFolderNotFound, InvalidPackageOrVersionError) as e:
+        raise e
+
+    file_ = SourceFile(location)
+
+    sources_path = file_.get_raw_url().replace(
+        config['SOURCES_STATIC'],
+        config['SOURCES_DIR'],
+        1)
+    return sources_path
+
+
+def parse_license(sources_path):
+    with io.open(sources_path, mode='rt', encoding='utf-8') as f:
+        try:
+            c = copyright.Copyright(f)
+            return c
+        except Exception as e:
+            raise e
+
+
+def license_url(package, version):
+    return url_for('.license', path_to=(package + '/' + version))
+
+
+def get_license(session, package, version, path):
+    try:
+        sources_path = get_sources_path(session, package, version,
+                                        current_app.config)
+    except (FileOrFolderNotFound, InvalidPackageOrVersionError):
+        raise Http404ErrorSuggestions(package, version, '')
+
+    try:
+        c = parse_license(sources_path)
+    except Exception:
+        return None
+
+    # search for path in globs
+    path_dict = path.split('/')
+    for par in c.all_files_paragraphs():
+        for glob in par.files:
+            if glob == path_dict[-1]:
+                return par.license.synopsis
+
+    # search for folder/* containing our file
+    # search in reverse order as we can have f1/f2/filename
+    # where f1/* with license1 and f2/* in another
+    for folder in reversed(path_dict):
+        for par in c.all_files_paragraphs():
+            for glob in par.files:
+                if glob.replace('/*', '') == folder:
+                    return par.license.synopsis
+
+    # TODO search for /*
+    for par in c.all_files_paragraphs():
+        for glob in par.files:
+            if glob == '*':
+                return par.license.synopsis

--- a/debsources/app/copyright/routes.py
+++ b/debsources/app/copyright/routes.py
@@ -18,7 +18,7 @@ from ..helper import bind_render
 from . import bp_copyright
 from ..views import (IndexView, PrefixView, ListPackagesView, ErrorHandler,
                      Ping, PackageVersionsView)
-from .views import LicenseView
+from .views import LicenseView, ChecksumLicenseView
 
 
 # context vars
@@ -111,3 +111,13 @@ bp_copyright.add_url_rule(
         'license',
         render_func=bind_render('copyright/license.html'),
         err_func=ErrorHandler('copyright')))
+
+# CHECKSUM VIEW
+
+# api
+bp_copyright.add_url_rule(
+    '/api/sha256/',
+    view_func=ChecksumLicenseView.as_view(
+        'api_checksum',
+        render_func=jsonify,
+        err_func=ErrorHandler(mode='json')))

--- a/debsources/app/copyright/routes.py
+++ b/debsources/app/copyright/routes.py
@@ -18,7 +18,7 @@ from ..helper import bind_render
 from . import bp_copyright
 from ..views import (IndexView, PrefixView, ListPackagesView, ErrorHandler,
                      Ping, PackageVersionsView)
-from .views import LicenseView, ChecksumLicenseView
+from .views import LicenseView, ChecksumLicenseView, SearchFileView
 
 
 # context vars
@@ -119,5 +119,16 @@ bp_copyright.add_url_rule(
     '/api/sha256/',
     view_func=ChecksumLicenseView.as_view(
         'api_checksum',
+        render_func=jsonify,
+        err_func=ErrorHandler(mode='json')))
+
+
+# FileSearch VIEW
+
+# api
+bp_copyright.add_url_rule(
+    '/api/file/<path:path_to>/',
+    view_func=SearchFileView.as_view(
+        'api_file',
         render_func=jsonify,
         err_func=ErrorHandler(mode='json')))

--- a/debsources/app/copyright/views.py
+++ b/debsources/app/copyright/views.py
@@ -10,17 +10,17 @@
 # https://anonscm.debian.org/gitweb/?p=qa/debsources.git;a=blob;f=COPYING;hb=HEAD
 
 from __future__ import absolute_import
-import io
 
-from flask import current_app
-from debian import copyright
+from flask import current_app, request
 
-from debsources.navigation import Location, SourceFile
+import debsources.query as qry
 from debsources.excepts import (Http404ErrorSuggestions, FileOrFolderNotFound,
                                 InvalidPackageOrVersionError)
-from ..views import GeneralView, session
+
+from ..views import GeneralView, ChecksumView, session
 from ..sourcecode import SourceCodeIterator
 from ..render import RenderLicense
+from . import license_helper as helper
 
 
 class LicenseView(GeneralView):
@@ -43,38 +43,61 @@ class LicenseView(GeneralView):
             redirect_url = '/'.join(redirect_url_parts)
             return self._redirect_to_url(redirect_url,
                                          redirect_code=302)
+
         try:
-            location = Location(session,
-                                current_app.config["SOURCES_DIR"],
-                                current_app.config["SOURCES_STATIC"],
-                                package, version, 'debian/copyright')
-        except (FileOrFolderNotFound, InvalidPackageOrVersionError):
-            raise Http404ErrorSuggestions(package,
-                                          version, 'debian/copyright')
+            sources_path = helper.get_sources_path(session, package, version,
+                                                   current_app.config)
+        except (FileOrFolderNotFound, InvalidPackageOrVersionError) as e:
+            if isinstance(e, FileOrFolderNotFound):
+                raise Http404ErrorSuggestions(package, version,
+                                              'debian/copyright')
+            else:
+                raise Http404ErrorSuggestions(package, version, '')
 
-        file_ = SourceFile(location)
-
-        sources_path = file_.get_raw_url().replace(
-            current_app.config['SOURCES_STATIC'],
-            current_app.config['SOURCES_DIR'],
-            1)
-        with io.open(sources_path, mode='rt', encoding='utf-8') as f:
-            # change render function
-            try:
-                c = copyright.Copyright(f)
-            except Exception:
-                # non machine readable license
-                sourcefile = SourceCodeIterator(sources_path)
-                return dict(package=package,
-                            version=version,
-                            code=sourcefile,
-                            dump='True',
-                            nlines=sourcefile.get_number_of_lines(),)
-            renderer = RenderLicense(c, 'jinja')
+        try:
+            c = helper.parse_license(sources_path)
+        except Exception:
+            # non machine readable license
+            sourcefile = SourceCodeIterator(sources_path)
             return dict(package=package,
                         version=version,
-                        dump='False',
-                        header=renderer.render_header(),
-                        files=renderer.render_files(
-                            "/src/" + package + "/" + version + "/"),
-                        licenses=renderer.render_licenses())
+                        code=sourcefile,
+                        dump='True',
+                        nlines=sourcefile.get_number_of_lines(),)
+        renderer = RenderLicense(c, 'jinja')
+        return dict(package=package,
+                    version=version,
+                    dump='False',
+                    header=renderer.render_header(),
+                    files=renderer.render_files(
+                        "/src/" + package + "/" + version + "/"),
+                    licenses=renderer.render_licenses())
+
+
+class ChecksumLicenseView(ChecksumView):
+
+    def _license_of_files(self, checksum, package, suite):
+        files = ChecksumView._files_with_sum(
+            checksum, slice_=None, package=package, suite=suite)
+        return [dict(oracle='debian',
+                     path=f['path'],
+                     package=f['package'],
+                     version=f['version'],
+                     license=helper.get_license(session, f['package'],
+                                                f['version'], f['path']),
+                     origin=helper.license_url(f['package'], f['version']))
+                for f in files]
+
+    def get_objects(self, **kwargs):
+        checksum = request.args.get("checksum")
+        package = request.args.get("package") or None
+        suite = request.args.get("suite") or None
+        # we count the number of results:
+        count = qry.count_files_checksum(session, checksum, package, suite)
+        count = count.first()[0]
+
+        d_copyright = self._license_of_files(checksum, package, suite)
+
+        return dict(sha256=checksum,
+                    count=count,
+                    copyright=d_copyright)

--- a/debsources/app/sources/views.py
+++ b/debsources/app/sources/views.py
@@ -95,8 +95,7 @@ class SourceView(GeneralView):
                 redirect_url = os.path.normpath(
                     os.path.join(os.path.dirname(location.path_to),
                                  symlink_dest))
-
-                return self._redirect_to_url(redirect_url)
+                return self._redirect_to_url(request.endpoint, redirect_url)
             else:
                 raise Http403Error(
                     'insecure symlink, pointing outside package/version/')
@@ -246,7 +245,7 @@ class SourceView(GeneralView):
         path = '/'.join(path_dict[2:])
 
         if version == "latest":  # we search the latest available version
-            return self._handle_latest_version(package, path)
+            return self._handle_latest_version(request.endpoint, package, path)
 
         versions = self.handle_versions(version, package, path)
         if versions and version:
@@ -254,7 +253,7 @@ class SourceView(GeneralView):
             if path:
                 redirect_url_parts.append(path)
             redirect_url = '/'.join(redirect_url_parts)
-            return self._redirect_to_url(redirect_url,
+            return self._redirect_to_url(request.endpoint, redirect_url,
                                          redirect_code=302)
 
         return self._render_location(package, version, path)

--- a/debsources/app/views.py
+++ b/debsources/app/views.py
@@ -169,7 +169,7 @@ class GeneralView(View):
 
         if get_objects:
             if isinstance(get_objects, six.string_types):
-                self.get_objects = getattr(self, "get_"+get_objects)
+                self.get_objects = getattr(self, "get_" + get_objects)
             else:
                 # we don't check if it's a callable.
                 # if err, then let it err.
@@ -364,12 +364,12 @@ class SearchView(GeneralView):
 class ChecksumView(GeneralView):
 
     @staticmethod
-    def _files_with_sum(checksum, slice_=None, package=None):
+    def _files_with_sum(checksum, slice_=None, package=None, suite=None):
         """
         Returns a list of files whose hexdigest is checksum.
         You can slice the results, passing slice=(start, end).
         """
-        results = qry.get_files_by_checksum(session, checksum, package)
+        results = qry.get_files_by_checksum(session, checksum, package, suite)
 
         if slice_ is not None:
             results = results.slice(slice_[0], slice_[1])

--- a/debsources/app/views.py
+++ b/debsources/app/views.py
@@ -198,27 +198,18 @@ class GeneralView(View):
         except Exception as e:
             return self.err_func(e, http=500)
 
-    def _redirect_to_url(self, redirect_url, redirect_code=301):
-        if self.d.get('api'):
-            if request.blueprint == 'sources':
-                endpoint = '.api_source'
-            elif request.blueprint == 'copyright':
-                endpoint = '.api_license'
+    def _redirect_to_url(self, endpoint, redirect_url, redirect_code=301):
+        if endpoint == '.versions':
             self.render_func = bind_redirect(url_for(endpoint,
-                                             path_to=redirect_url),
-                                             code=302)
+                                             packagename=redirect_url),
+                                             code=redirect_code)
         else:
-            if request.blueprint == 'sources':
-                endpoint = '.source'
-            elif request.blueprint == 'copyright':
-                endpoint = '.license'
             self.render_func = bind_redirect(url_for(endpoint,
                                              path_to=redirect_url),
                                              code=redirect_code)
-
         return dict(redirect=redirect_url)
 
-    def _handle_latest_version(self, package, path):
+    def _handle_latest_version(self, endpoint, package, path):
         """
         redirects to the latest version for the requested page,
         when 'latest' is provided instead of a version number
@@ -238,7 +229,7 @@ class GeneralView(View):
         else:
             redirect_url = '/'.join([package, version, path])
 
-        return self._redirect_to_url(redirect_url)
+        return self._redirect_to_url(endpoint, redirect_url)
 
     def handle_versions(self, version, package, path):
         check_for_alias = session.query(SuiteAlias) \

--- a/debsources/query.py
+++ b/debsources/query.py
@@ -299,6 +299,26 @@ def get_files_by_checksum(session, checksum, package=None, suite=None):
     return results.order_by("package", "version", "path")
 
 
+def get_files_by_path_package(session, path, package, version=None):
+    """ Return a list of files with a specific `path` and `package`
+        Filter with `suite`
+    """
+    results = (session.query(File.path.label("path"),
+                             PackageName.name.label("package"),
+                             Package.version.label("version"),
+                             Checksum.sha256.label("checksum"))
+               .filter(File.path == path)
+               .filter(File.package_id == Package.id)
+               .filter(Package.name_id == PackageName.id)
+               .filter(PackageName.name == package)
+               .filter(Checksum.file_id == File.id))
+
+    if version is not None and version is not "":
+        results = results.filter(Package.version == version)
+
+    return results.order_by("package", "version", "path")
+
+
 def get_pkg_filter_prefix(session, prefix, suite=None):
     '''Get packages filter by `prefix`
 

--- a/debsources/query.py
+++ b/debsources/query.py
@@ -119,7 +119,7 @@ def location_get_path_links(endpoint, path_to):
 
     for (i, p) in enumerate(path_dict):
         pathl.append((p, url_for(endpoint,
-                                 path_to='/'.join(path_dict[:i+1]))))
+                                 path_to='/'.join(path_dict[:i + 1]))))
     return pathl
 
 
@@ -141,13 +141,13 @@ def location_get_stat(sources_path):
         (stat.S_IROTH, "r", "-"),
         (stat.S_IWOTH, "w", "-"),
         (stat.S_IXOTH, "x", "-"),
-        ]
+    ]
     # XXX these flags should be enough.
     type_flags = [
         (stat.S_ISLNK, "l"),
         (stat.S_ISREG, "-"),
         (stat.S_ISDIR, "d"),
-        ]
+    ]
     # add the file type: d/l/-
     file_type = " "
     for ft, sign in type_flags:
@@ -212,7 +212,7 @@ def get_suite_info(session, suite, first=None):
     return session.query(SuiteInfo).filter(SuiteInfo.name == suite).first()
 
 
-def count_files_checksum(session, checksum, pkg=None):
+def count_files_checksum(session, checksum, pkg=None, suite=None):
     '''Count files with `checksum`
 
     '''
@@ -223,6 +223,9 @@ def count_files_checksum(session, checksum, pkg=None):
         result = (result.filter(PackageName.name == pkg)
                   .filter(Checksum.package_id == Package.id)
                   .filter(Package.name_id == PackageName.id))
+    if suite is not None and suite is not "":
+        result = (result.filter(Suite.suite == suite)
+                  .filter(Suite.package_id == Checksum.package_id))
     return result
 
 
@@ -270,7 +273,7 @@ def filter_pkg_by_suite(session, result, suite):
             )
 
 
-def get_files_by_checksum(session, checksum, package=None):
+def get_files_by_checksum(session, checksum, package=None, suite=None):
     ''' Returns a list of files whose hexdigest is checksum.
         Filter with package
 
@@ -288,6 +291,10 @@ def get_files_by_checksum(session, checksum, package=None):
     if package is not None and package != "":
 
         results = results.filter(PackageName.name == package)
+
+    if suite is not None and suite is not "":
+        results = (results.filter(Suite.suite == suite)
+                   .filter(Suite.package_id == Checksum.package_id))
 
     return results.order_by("package", "version", "path")
 

--- a/debsources/tests/test_web_cp.py
+++ b/debsources/tests/test_web_cp.py
@@ -159,5 +159,49 @@ class CopyrightTestCase(DebsourcesBaseWebTests, unittest.TestCase):
         self.assertLessEqual(len(rv['result']['copyright']),
                              len(rv2['result']['copyright']))
 
+    def test_api_search_filename_package(self):
+        # test package requirement
+        '''rv = json.loads(self.app.get(
+            "/copyright/api/file/random/debian/copyright/").data)
+        self.assertEqual(rv['error'], 'File not found')
+        self.assertEqual(rv['return_code'], 404)'''
+
+        rv = json.loads(self.app.get(
+            "/copyright/api/file/gnubg/1.02.000-2/Makefile.am/").data)
+        self.assertEqual(len(rv['result']), 1)
+        self.assertEqual(rv['result'][0]['copyright']['path'], 'Makefile.am')
+        self.assertEqual(rv['result'][0]['copyright']['license'], 'GPL-3+')
+
+        # test with folder
+        rv = json.loads(self.app.get(
+            "/copyright/api/file/gnubg/0.90+20120429-1/"
+            "doc/gnubg/gnubg.html/").data)
+        self.assertEqual(rv['result'][0]['copyright']['license'], None)
+
+    def test_api_search_filename_suite_filter(self):
+        rv = json.loads(self.app.get(
+            "/copyright/api/file/gnubg/wheezy/doc/gnubg/gnubg.html/",
+            follow_redirects=True).data)
+        self.assertEqual(rv['result'][0]['copyright']['version'],
+                         '0.90+20120429-1')
+        rv = json.loads(self.app.get(
+            "/copyright/api/file/gnubg/squeeze/doc/gnubg/gnubg.html/",
+            follow_redirects=True).data)
+        self.assertEqual(rv['result'][0]['copyright']['version'],
+                         '0.90+20091206-4')
+
+    def test_api_search_filename_latest(self):
+        rv = json.loads(self.app.get(
+            "/copyright/api/file/gnubg/latest/doc/gnubg/gnubg.html/",
+            follow_redirects=True).data)
+        self.assertEqual(rv['result'][0]['copyright']['version'],
+                         '1.02.000-2')
+
+    def test_api_search_filename_all(self):
+        rv = json.loads(self.app.get(
+            "/copyright/api/file/gnubg/all/doc/gnubg/gnubg.html/").data)
+        self.assertEqual(len(rv['result']), 3)
+
+
 if __name__ == '__main__':
     unittest.main(exit=False)

--- a/debsources/tests/test_web_cp.py
+++ b/debsources/tests/test_web_cp.py
@@ -78,5 +78,73 @@ class CopyrightTestCase(DebsourcesBaseWebTests, unittest.TestCase):
         rv = self.app.get('/copyright/license/gnubg/1.02.000-2/')
         self.assertIn("<p class=\'r_glob\'>", rv.data)
 
+    def test_checksum_api(self):
+        rv = json.loads(self.app.get(
+            '/copyright/api/sha256/'
+            '?checksum=be43f81c20961702327'
+            'c10e9bd5f5a9a2b1cceea850402ea562a9a76abcf'
+            'a4bf').data)
+
+        # verify number of files in d/copyright
+        self.assertEqual(rv['count'], len(rv['copyright']))
+
+        self.assertEqual(rv['copyright'][0]['license'], None)
+        self.assertEqual(rv['copyright'][1]['license'],
+                         'BSD')
+        self.assertEqual(rv['copyright'][2]['package'],
+                         'bsdgames-nonfree')
+        self.assertEqual(rv['copyright'][2]['version'],
+                         '2.17-6')
+        self.assertEqual(rv['copyright'][2]['path'],
+                         'COPYING')
+
+        # verify folder/* /* functionnality
+        rv = json.loads(self.app.get(
+            '/copyright/api/sha256/'
+            '?checksum=2e6d31a5983a91251bfae5'
+            'aefa1c0a19d8ba3cf601d0e8a706b4cfa9661a6b8a').data)
+
+        self.assertEqual(rv['count'], 12)
+        # debian/* under gpl2
+        self.assertEqual(rv['copyright'][6]['license'],
+                         'GPL-2+')
+        # /* under gpl2
+        self.assertEqual(rv['copyright'][8]['license'],
+                         'GPL-2+')
+
+        # need test for /f1/f2/filename where f1/* under l1 and f2/* under l2
+
+    def test_package_filter_checksum(self):
+        rv = json.loads(self.app.get(
+            '/copyright/api/sha256/'
+            '?checksum=2e6d31a5983a91251bfae5'
+            'aefa1c0a19d8ba3cf601d0e8a70'
+            '6b4cfa9661a6b8a&package=gnubg').data)
+        self.assertEqual(rv['count'], 2)
+        self.assertEqual(rv['copyright'][0]['package'],
+                         'gnubg')
+        self.assertNotEqual(rv['copyright'][0]['version'],
+                            rv['copyright'][1]['version'])
+
+    def test_suite_filter_checksum(self):
+        rv = json.loads(self.app.get(
+            '/copyright/api/sha256/'
+            '?checksum=2e6d31a5983a91251bfae5'
+            'aefa1c0a19d8ba3cf601d0e8a70'
+            '6b4cfa9661a6b8a&suite=etch').data)
+        self.assertEqual(rv['count'], 0)
+        rv = json.loads(self.app.get(
+            '/copyright/api/sha256/'
+            '?checksum=2e6d31a5983a91251bfae5'
+            'aefa1c0a19d8ba3cf601d0e8a70'
+            '6b4cfa9661a6b8a&suite=jessie').data)
+        rv2 = json.loads(self.app.get(
+            '/copyright/api/sha256/'
+            '?checksum=2e6d31a5983a91251bfae5'
+            'aefa1c0a19d8ba3cf601d0e8a70'
+            '6b4cfa9661a6b8a').data)
+        self.assertGreaterEqual(rv2['count'], rv['count'])
+
+
 if __name__ == '__main__':
     unittest.main(exit=False)

--- a/doc/copyright.debian.net-api.txt
+++ b/doc/copyright.debian.net-api.txt
@@ -16,7 +16,7 @@ URL schema
   * Optional parameter package name: &package=
   * Optional parameter suite : &suite=
 
-* /copyright/api/file/?path=--&package=--
+* /copyright/api/file/path/?package=--
 
   * Optional parameter suite : &suite=
   * Package is not optional. Otherwise finding the file would consume a lot of


### PR DESCRIPTION
This PR is about the file-by-file API. It implements:
- checksum search
- filename & package search
- suite filter ( name or latest) for both searches

Compared to the api doc there are two differences:

url for file name & package search is slightly different using
/copyright/api/file/path/?package=--
instead of
/copyright/api/file/?path=--&package=--
as it is easier and better to handle paths

The json output for filename and package search differs as if the user doesn't specify a suite name the results can be > 1 with different checksums. The solution was to include everything in a result field. I didn't update the doc for this one as you might have a better solution to come up with.
