### PR TITLE
File by file views

### DIFF
--- a/debsources/app/copyright/routes.py
+++ b/debsources/app/copyright/routes.py
@@ -114,6 +114,14 @@ bp_copyright.add_url_rule(
 
 # CHECKSUM VIEW
 
+bp_copyright.add_url_rule(
+    '/sha256/',
+    view_func=ChecksumLicenseView.as_view(
+        'checksum',
+        render_func=bind_render('copyright/checksum.html'),
+        err_func=ErrorHandler('copyright'),
+        pagination=True))
+
 # api
 bp_copyright.add_url_rule(
     '/api/sha256/',

--- a/debsources/app/copyright/routes.py
+++ b/debsources/app/copyright/routes.py
@@ -133,6 +133,13 @@ bp_copyright.add_url_rule(
 
 # FileSearch VIEW
 
+bp_copyright.add_url_rule(
+    '/file/<path:path_to>/',
+    view_func=SearchFileView.as_view(
+        'file',
+        render_func=bind_render('copyright/file.html'),
+        err_func=ErrorHandler('copyright')))
+
 # api
 bp_copyright.add_url_rule(
     '/api/file/<path:path_to>/',

--- a/debsources/app/copyright/templates/copyright/checksum.html
+++ b/debsources/app/copyright/templates/copyright/checksum.html
@@ -1,0 +1,52 @@
+{#
+  Copyright (C) 2015  The Debsources developers <info@sources.debian.net>.
+  See the AUTHORS file at the top-level directory of this distribution and at
+  https://anonscm.debian.org/gitweb/?p=qa/debsources.git;a=blob;f=AUTHORS;hb=HEAD
+  License: GNU Affero General Public License, version 3 or above.
+#}
+{# copied from templates/checksum.html #}
+
+{% extends name+"/base.html" %}
+
+{% block title %}Checksum: {{ checksum }}{% endblock %}
+
+{% block breadcrumbs %}checksum / {{ checksum }}{% endblock %}
+
+{% block content %}
+<h2>{{ self.title() }}</h2>
+{% import "copyright/macros.html" as macro %}
+{% if count > 1 %}
+  <h3>Summary</h3>
+  <p>This checksum appears {{ count }} times in our database. It appears in under the following licenses:
+  <ul>
+  {% for l in licenses %}
+    <li>{{l}}</li>
+  {% endfor %}
+  </ul>
+
+  {% if package_filter != true %}
+    <p>Most frequent package{% if frequent_packages|length > 1 %}s are: {% for p in frequent_packages %} {{ p }} {% endfor %}
+    {% else %} is: {{ frequent_packages[0] }}{% endif %}</p>
+  {% endif %}
+  {% if frequent_licenses|length != 0 %}
+    <p>Most frequent license{% if frequent_licenses|length > 1 %}s are: {% for l in frequent_licenses %} {{ l }} {% endfor %}
+    {% else %} is: {{ frequent_licenses[0] }}{% endif %}</p>
+    <h3>Details</h3>
+  {% endif %}
+  
+  {% for c in copyright %}
+    {{ macro.view_license(c) }}
+  {% endfor %}
+  
+  {% if pagination != none%}
+  {{ macros.render_pagination(pagination) }}
+  {% endif %}
+
+{% elif count == 0 %}
+  <p>0 results</p>
+{% else %}
+  <h3>Summary</h3>
+  <p>This checksum appears {{ count }} time in our database.</p>
+  {{ macro.view_license(copyright[0]) }}
+{% endif %}
+{% endblock %}

--- a/debsources/app/copyright/templates/copyright/file.html
+++ b/debsources/app/copyright/templates/copyright/file.html
@@ -1,0 +1,29 @@
+{#
+  Copyright (C) 2015  The Debsources developers <info@sources.debian.net>.
+  See the AUTHORS file at the top-level directory of this distribution and at
+  https://anonscm.debian.org/gitweb/?p=qa/debsources.git;a=blob;f=AUTHORS;hb=HEAD
+  License: GNU Affero General Public License, version 3 or above.
+#}
+{# copied from templates/checksum.html #}
+
+{% extends name+"/base.html" %}
+
+{% block title %}Filename: {{ path }}{% endblock %}
+
+{% block breadcrumbs %}file name / {{ path }}{% endblock %}
+
+{% block content %}
+{% import "copyright/macros.html" as macro %}
+<h2>{{ self.title() }}</h2>
+
+{% if count == 0 %}
+    <p>File {{ path }} in {{ package }} in version {{ version }} not found</p>
+{% else %}
+    {% if count > 1 %}
+        <h4>File name appears {{ count }} times in the package {{ package }}</h4>
+    {% endif %}
+    {% for res in result %}
+        {{ macro.view_license(res['copyright']) }}
+    {% endfor %}
+{% endif %}
+{% endblock %}

--- a/debsources/app/copyright/templates/copyright/macros.html
+++ b/debsources/app/copyright/templates/copyright/macros.html
@@ -7,3 +7,11 @@
         {% endif %}
     {% endfor %}
 {% endmacro %}
+
+{% macro view_license(c) -%}
+    {% if c['license'] is not none %}
+      <p>According to the <a href="{{url_for('.license', path_to=(c['package']+'/'+c['version']))}}">d/copyright</a> file, <b>{{c['path']}}</b> in the package <b>{{c['package']}}</b>, version <b>{{c['version']}}</b> is licensed under <b>{{c['license']}}</b></p>
+    {% else %}
+        <p>The <a href="{{url_for('.license', path_to=(c['package']+'/'+c['version']))}}">d/copyright</a> file for the file <b>{{c['path']}}</b> in the package <b>{{c['package']}}</b>, version <b>{{c['version']}}</b> is not machine readable</p>
+    {% endif %}
+{% endmacro %}

--- a/debsources/app/copyright/views.py
+++ b/debsources/app/copyright/views.py
@@ -11,7 +11,7 @@
 
 from __future__ import absolute_import
 
-from collections import defaultdict
+from collections import defaultdict, Counter
 
 from flask import current_app, request
 from debian.debian_support import version_compare
@@ -23,6 +23,7 @@ from debsources.excepts import (Http404ErrorSuggestions, FileOrFolderNotFound,
 from ..views import GeneralView, ChecksumView, session
 from ..sourcecode import SourceCodeIterator
 from ..render import RenderLicense
+from ..pagination import Pagination
 from . import license_helper as helper
 
 
@@ -80,26 +81,23 @@ class LicenseView(GeneralView):
 
 class ChecksumLicenseView(ChecksumView):
 
-    def _license_of_files(self, checksum, package, suite):
-        if suite == 'latest':
-            files = ChecksumView._files_with_sum(
-                checksum, slice_=None, package=package)
-            # find latest version of each package
-            dd = defaultdict(list)
-            for f in files:
-                dd[(f['package'])].append(f)
-            files = []
-            for package in dd:
-                version = sorted([item['version'] for item
-                                 in dd[package]],
-                                 cmp=version_compare)[-1]
-                files.append(filter(lambda f: f['version'] == version,
-                                    dd[package])[0])
-        else:
-            files = ChecksumView._files_with_sum(
-                checksum, slice_=None, package=package, suite=suite)
-        # Not list comprehension to catch error when d/copyright file is not
-        # present in the package.
+    def _license_latest_files(self, checksum, package):
+        files = ChecksumView._files_with_sum(
+            checksum, slice_=None, package=package)
+        # find latest version of each package
+        dd = defaultdict(list)
+        for f in files:
+            dd[(f['package'])].append(f)
+        files = []
+        for package in dd:
+            version = sorted([item['version'] for item
+                             in dd[package]],
+                             cmp=version_compare)[-1]
+            files.append(filter(lambda f: f['version'] == version,
+                                dd[package])[0])
+        return files
+
+    def _get_license_dict(self, files):
         result = []
         for f in files:
             try:
@@ -123,18 +121,77 @@ class ChecksumLicenseView(ChecksumView):
         return result
 
     def get_objects(self, **kwargs):
+        try:
+            page = int(request.args.get("page"))
+        except:
+            page = 1
         checksum = request.args.get("checksum")
         package = request.args.get("package") or None
         suite = request.args.get("suite") or None
 
-        d_copyright = self._license_of_files(checksum, package, suite)
+        # init values to avoid another if else in the return statement
+        pagination = None
+        slice_ = None
 
-        if len(d_copyright) is 0:
-            return dict(return_code=404,
-                        error='Checksum not found')
-        return dict(return_code=200,
-                    result=dict(checksum=checksum,
-                                copyright=d_copyright))
+        # all files is usefull for the small statistics we calculate in order
+        # to make sure all the pages (pagination) show the same stats
+        # For latest we can't predict number of results. do we run two times?
+        if suite == 'latest':
+            files = self._license_latest_files(checksum, package)
+            all_files = files
+        else:
+            count = qry.count_files_checksum(session, checksum, package, suite)
+            count = count.first()[0]
+            if self.d.get('pagination'):
+                offset = int(current_app.config.get("LIST_OFFSET") or 60)
+                start = (page - 1) * offset
+                end = start + offset
+                slice_ = (start, end)
+                pagination = Pagination(page, offset, count)
+
+            files = ChecksumView._files_with_sum(checksum, slice_,
+                                                 package=package, suite=suite)
+            all_files = ChecksumView._files_with_sum(checksum, slice_=None,
+                                                     package=package,
+                                                     suite=suite)
+
+        d_copyright = self._get_license_dict(files)
+
+        if 'api' in request.endpoint:
+            if len(d_copyright) is 0:
+                return dict(return_code=404,
+                            error='Checksum not found')
+            return dict(return_code=200,
+                        result=dict(checksum=checksum,
+                                    copyright=d_copyright))
+        else:
+            # minor stats
+            all_d_copyright = self._get_license_dict(all_files)
+            licenses = [x['license'] for x in all_d_copyright
+                        if x['license'] is not None]
+            counter = Counter(licenses).most_common()
+            f_license = [x[0] for x in counter if x[1] is counter[0][1]]
+
+            if package is None or len(all_d_copyright) < 2:
+                packages = [x['package'] for x in all_d_copyright]
+                counter = Counter(packages).most_common()
+                f_package = [x[0] for x in counter if x[1] is counter[0][1]]
+
+                return dict(checksum=checksum,
+                            copyright=d_copyright,
+                            count=len(all_d_copyright),
+                            licenses=set(licenses),
+                            frequent_packages=f_package,
+                            frequent_licenses=f_license,
+                            pagination=pagination)
+            else:
+                return dict(checksum=checksum,
+                            copyright=d_copyright,
+                            count=len(d_copyright),
+                            package_filter=True,
+                            licenses=set(licenses),
+                            frequent_licenses=f_license,
+                            pagination=pagination)
 
 
 class SearchFileView(GeneralView):

--- a/debsources/app/copyright/views.py
+++ b/debsources/app/copyright/views.py
@@ -140,8 +140,10 @@ class ChecksumLicenseView(ChecksumView):
             files = self._license_latest_files(checksum, package)
             all_files = files
         else:
-            count = qry.count_files_checksum(session, checksum, package, suite)
-            count = count.first()[0]
+            all_files = ChecksumView._files_with_sum(checksum, slice_=None,
+                                                     package=package,
+                                                     suite=suite)
+            count = len(all_files)
             if self.d.get('pagination'):
                 offset = int(current_app.config.get("LIST_OFFSET") or 60)
                 start = (page - 1) * offset
@@ -151,9 +153,6 @@ class ChecksumLicenseView(ChecksumView):
 
             files = ChecksumView._files_with_sum(checksum, slice_,
                                                  package=package, suite=suite)
-            all_files = ChecksumView._files_with_sum(checksum, slice_=None,
-                                                     package=package,
-                                                     suite=suite)
 
         d_copyright = self._get_license_dict(files)
 

--- a/debsources/app/copyright/views.py
+++ b/debsources/app/copyright/views.py
@@ -231,10 +231,21 @@ class SearchFileView(GeneralView):
         else:
             files = qry.get_files_by_path_package(session, path, package,
                                                   version).all()
-        if len(files) is 0:
-            return dict(return_code=404,
-                        error='File not found')
-        return dict(return_code=200,
-                    result=[dict(checksum=res.checksum,
-                            copyright=self._license_of_files(res))
-                            for res in files])
+
+        if 'api' in request.endpoint:
+            if len(files) is 0:
+                return dict(return_code=404,
+                            error='File not found')
+            return dict(return_code=200,
+                        count=len(files),
+                        result=[dict(checksum=res.checksum,
+                                copyright=self._license_of_files(res))
+                                for res in files])
+        else:
+            return dict(count=len(files),
+                        path=path,
+                        package=package,
+                        version=version,
+                        result=[dict(checksum=res.checksum,
+                                copyright=self._license_of_files(res))
+                                for res in files])

--- a/debsources/tests/test_web_cp.py
+++ b/debsources/tests/test_web_cp.py
@@ -159,6 +159,43 @@ class CopyrightTestCase(DebsourcesBaseWebTests, unittest.TestCase):
         self.assertLessEqual(len(rv['result']['copyright']),
                              len(rv2['result']['copyright']))
 
+    def test_checksum_view(self):
+        rv = self.app.get("/copyright/sha256/?checksum="
+                          "2e6d31a5983a91251bfae5aefa1c0a"
+                          "19d8ba3cf601d0e8a706b4cfa9661a6b8a")
+        self.assertIn("This checksum appears 12 times", rv.data)
+        self.assertIn("Most frequent license is: GPL-2+", rv.data)
+
+    def test_checksum_view_package_filter(self):
+        rv = self.app.get("/copyright/sha256/?checksum="
+                          "2e6d31a5983a91251bfae5aefa1c0a"
+                          "19d8ba3cf601d0e8a706b4cfa9661a6b8a&package=gnubg")
+        self.assertIn("This checksum appears 2 times", rv.data)
+        self.assertNotIn("Most common package", rv.data)
+
+    def test_checksum_view_suite_filter(self):
+        rv = self.app.get("/copyright/sha256/?checksum="
+                          "2e6d31a5983a91251bfae5aefa1c0a"
+                          "19d8ba3cf601d0e8a706b4cfa9661a6b8a&suite=latest")
+        self.assertIn("This checksum appears 8 times", rv.data)
+        rv = self.app.get("/copyright/sha256/?checksum="
+                          "2e6d31a5983a91251bfae5aefa1c0a"
+                          "19d8ba3cf601d0e8a706b4cfa9661a6b8a&suite=jessie")
+        self.assertIn("This checksum appears 7 times", rv.data)
+
+    def test_checksum_view_one_result(self):
+        rv = self.app.get("/copyright/sha256/?checksum="
+                          "2e6d31a5983a91251bfae5aefa1c0a"
+                          "19d8ba3cf601d0e8a706b4cfa9661a6b8a&package=beignet")
+        self.assertIn("This checksum appears 1 time", rv.data)
+        self.assertNotIn("<h3>Details</h3>", rv.data)
+
+    def test_checksum_404(self):
+        rv = self.app.get("/copyright/sha256/?checksum="
+                          "2e6d31a5983a91251bfae5aefa1c0a19d8"
+                          "ba3cf60d0e8a706b4cfa9661a6b8a")
+        self.assertIn("0 results", rv.data)
+
     def test_api_search_filename_package(self):
         # test package requirement
         '''rv = json.loads(self.app.get(

--- a/debsources/tests/test_web_cp.py
+++ b/debsources/tests/test_web_cp.py
@@ -239,6 +239,26 @@ class CopyrightTestCase(DebsourcesBaseWebTests, unittest.TestCase):
             "/copyright/api/file/gnubg/all/doc/gnubg/gnubg.html/").data)
         self.assertEqual(len(rv['result']), 3)
 
+    def test_search_filename_all(self):
+        rv = self.app.get(
+            "/copyright/file/gnubg/all/doc/gnubg/gnubg.html/").data
+        self.assertIn("File name appears 3", rv)
+
+    def test_search_filename_suite_non_existing(self):
+        rv = self.app.get(
+            "/copyright/file/gnubg/not/doc/gnubg/gnubg.html/").data
+        self.assertIn("not found", rv)
+
+    def test_search_filename_suite_filter(self):
+        rv = self.app.get("/copyright/file/gnubg/jessie/doc/gnubg/gnubg.html/",
+                          follow_redirects=True)
+        self.assertNotIn("File name appears", rv.data)
+
+    def test_search_filename(self):
+        rv = self.app.get("/copyright/file/gnubg/1.02.000-2"
+                          "/doc/gnubg/gnubg.html/", follow_redirects=True)
+        self.assertIn("GPL-3+", rv.data)
+
 
 if __name__ == '__main__':
     unittest.main(exit=False)


### PR DESCRIPTION
This PR created the views for the previously merged api file-by-file functionnalities.
Some routes are: 
copyright/file/gnubg/1.02.000-2/doc/gnubg/gnubg.html/ 
copyright/file/gnubg/all/doc/gnubg/gnubg.html/ 
/copyright/sha256/?checksum=2e6d31a5983a91251bfae5aefa1c0a19d8ba3cf601d0e8a706b4cfa9661a6b8a

Some things to checkout:
- Searching by checksum might give quite a lot of results so i added the pagination. There is an issue though. With the optional parameter 'latest' we cannot predict the number of results. Do we run the query two times so we have pagination as well? (for the moment with latest it is disabled)..
- For the checksum view i included some stats, i.e most frequent license, all the licenses of the checksum etc. To achieve this i have to calculate the query two times (once using the slice for the pagination, and once without). I am looking into better solutions as for some checksums this might be troublesome but i can exclude it you think it is unnecessary.
- For the filename/package/version search i haven't added 'other' results just yet. 
