### PR TITLE
Refresh sticky plots

### DIFF
--- a/bin/debsources-suite-archive
+++ b/bin/debsources-suite-archive
@@ -23,13 +23,14 @@ import sys
 from debsources import archiver
 from debsources import debmirror
 from debsources import mainlib
+from debsources import updater
 
 
 def main():
     cmdline = argparse.ArgumentParser(description='Debsources suite '
                                       'archive manager')
     cmdline.add_argument('action', metavar='ACTION',
-                         choices=['add', 'list', 'remove'],
+                         choices=['add', 'list', 'remove', 'refresh'],
                          help='action to perform on the archive of '
                          'sticky suites')
     cmdline.add_argument('suite', metavar='SUITE', nargs='?', default=None,
@@ -39,7 +40,8 @@ def main():
     args = cmdline.parse_args()
     if args.action in ['add', 'remove'] and args.suite is None:
         cmdline.error('%s requires a suite name' % args.action)
-
+    if args.action == 'refresh' and args.stages is None:
+        cmdline.error('%s requires a stage' % args.action)
     conf = mainlib.load_conf(args.conffile or mainlib.guess_conffile())
     mainlib.override_conf(conf, args)
     mainlib.init_logging(conf, mainlib.log_level_of_verbosity(args.verbose))
@@ -62,6 +64,9 @@ def main():
                       (suite, present['db'], present['archive']))
         elif args.action == 'remove':
             archiver.remove_suite(conf, session, args.suite)
+        elif args.action == 'refresh':
+            conf['refresh'] = True
+            updater.update(conf, session, stages=conf['stages'])
         if conf['single_transaction']:
             session.commit()
     except SystemExit:  # exit as requested

--- a/contrib/docker/config.ini
+++ b/contrib/docker/config.ini
@@ -13,6 +13,7 @@ sources_dir: 	 %(mirror_dir)s/pool
 python_dir:  	 %(root_dir)s/python
 mirror_dir:    	 %(root_dir)s/testdata/mirror
 pool_dir:        %(mirror_dir)s/pool
+mirror_archive_dir: %(root_dir)s/testdata/archive
 dry_run:     	 false
 # echoes or not the SQL requests to stdout (can be logged with Apache):
 sqlalchemy_echo: false

--- a/debsources/statistics.py
+++ b/debsources/statistics.py
@@ -60,13 +60,15 @@ def suites(session, suites='release'):
     return sorted(db_suites, cmp=by_release_date)
 
 
-def sticky_suites(session):
+def sticky_suites(session, order=None):
     """list sticky suites currently present in Debsources DB
 
     """
     q = session.query(SuiteInfo.name) \
                .filter(SuiteInfo.sticky == True)  # NOQA,
     # '== True' can be dropped starting with sqlalchemy >= 0.8
+    if order:
+        q = q.order_by("release_date")
     return [row[0] for row in q]
 
 

--- a/etc/config.travis.ini
+++ b/etc/config.travis.ini
@@ -13,6 +13,7 @@ sources_dir: 	 %(mirror_dir)s/pool
 python_dir:  	 %(root_dir)s/python
 mirror_dir:    	 %(root_dir)s/testdata/mirror
 pool_dir:        %(mirror_dir)s/pool
+mirror_archive_dir: %(root_dir)s/testdata/archive
 dry_run:     	 false
 # echoes or not the SQL requests to stdout (can be logged with Apache):
 sqlalchemy_echo: false


### PR DESCRIPTION
This is the patch available for the bug #781350
Ituses the debsources-suite-archive to enable refreshing the sticky suites plots. In addition it includes the sticky suites in the bar chart plot.
usage: bin/debsources-suite-archive refresh --stage charts

First commit re-includes a missing entry in the docker and travis conf files.
