### PR TITLE
File by file views

### DIFF
--- a/debsources/app/copyright/routes.py
+++ b/debsources/app/copyright/routes.py
@@ -134,6 +134,13 @@ bp_copyright.add_url_rule(
 
 # FileSearch VIEW
 
+bp_copyright.add_url_rule(
+    '/file/<path:path_to>/',
+    view_func=SearchFileView.as_view(
+        'file',
+        render_func=bind_render('copyright/file.html'),
+        err_func=ErrorHandler('copyright')))
+
 # api
 bp_copyright.add_url_rule(
     '/api/file/<path:path_to>/',

--- a/debsources/app/copyright/routes.py
+++ b/debsources/app/copyright/routes.py
@@ -114,6 +114,14 @@ bp_copyright.add_url_rule(
 
 # CHECKSUM VIEW
 
+bp_copyright.add_url_rule(
+    '/sha256/',
+    view_func=ChecksumLicenseView.as_view(
+        'checksum',
+        render_func=bind_render('copyright/checksum.html'),
+        err_func=ErrorHandler('copyright'),
+        pagination=True))
+
 # api
 bp_copyright.add_url_rule(
     '/api/sha256/',

--- a/debsources/app/copyright/templates/copyright/checksum.html
+++ b/debsources/app/copyright/templates/copyright/checksum.html
@@ -1,0 +1,52 @@
+{#
+  Copyright (C) 2015  The Debsources developers <info@sources.debian.net>.
+  See the AUTHORS file at the top-level directory of this distribution and at
+  https://anonscm.debian.org/gitweb/?p=qa/debsources.git;a=blob;f=AUTHORS;hb=HEAD
+  License: GNU Affero General Public License, version 3 or above.
+#}
+{# copied from templates/checksum.html #}
+
+{% extends name+"/base.html" %}
+
+{% block title %}Checksum: {{ checksum }}{% endblock %}
+
+{% block breadcrumbs %}checksum / {{ checksum }}{% endblock %}
+
+{% block content %}
+<h2>{{ self.title() }}</h2>
+{% import "copyright/macros.html" as macro %}
+{% if count > 1 %}
+  <h3>Summary</h3>
+  <p>This checksum appears {{ count }} times in our database. It appears in under the following licenses:
+  <ul>
+  {% for l in licenses %}
+    <li>{{l}}</li>
+  {% endfor %}
+  </ul>
+
+  {% if package_filter != true %}
+    <p>Most frequent package{% if frequent_packages|length > 1 %}s are: {% for p in frequent_packages %} <i>{{ p }}</i>{% if not loop.last %}, {% endif %} {% endfor %}
+    {% else %} is: <i>{{ frequent_packages[0] }}</i>{% endif %}</p>
+  {% endif %}
+  {% if frequent_licenses|length != 0 %}
+    <p>Most frequent license{% if frequent_licenses|length > 1 %}s are: {% for l in frequent_licenses %} <i>{{ l }}</i>{% if not loop.last %}, {% endif %} {% endfor %}
+    {% else %} is: <i>{{ frequent_licenses[0] }}</i>{% endif %}</p>
+    <h3>Details</h3>
+  {% endif %}
+  
+  {% for c in copyright %}
+    {{ macro.view_license(c) }}
+  {% endfor %}
+  
+  {% if pagination != none%}
+  {{ macros.render_pagination(pagination) }}
+  {% endif %}
+
+{% elif count == 0 %}
+  <p>0 results</p>
+{% else %}
+  <h3>Summary</h3>
+  <p>This checksum appears {{ count }} time in our database.</p>
+  {{ macro.view_license(copyright[0]) }}
+{% endif %}
+{% endblock %}

--- a/debsources/app/copyright/templates/copyright/file.html
+++ b/debsources/app/copyright/templates/copyright/file.html
@@ -1,0 +1,29 @@
+{#
+  Copyright (C) 2015  The Debsources developers <info@sources.debian.net>.
+  See the AUTHORS file at the top-level directory of this distribution and at
+  https://anonscm.debian.org/gitweb/?p=qa/debsources.git;a=blob;f=AUTHORS;hb=HEAD
+  License: GNU Affero General Public License, version 3 or above.
+#}
+{# copied from templates/checksum.html #}
+
+{% extends name+"/base.html" %}
+
+{% block title %}Filename: {{ path }}{% endblock %}
+
+{% block breadcrumbs %}file name / {{ path }}{% endblock %}
+
+{% block content %}
+{% import "copyright/macros.html" as macro %}
+<h2>{{ self.title() }}</h2>
+
+{% if count == 0 %}
+    <p>File {{ path }} in {{ package }} in version {{ version }} not found</p>
+{% else %}
+    {% if count > 1 %}
+        <h4>File name appears {{ count }} times in the package {{ package }}</h4>
+    {% endif %}
+    {% for res in result %}
+        {{ macro.view_license(res['copyright']) }}
+    {% endfor %}
+{% endif %}
+{% endblock %}

--- a/debsources/app/copyright/templates/copyright/macros.html
+++ b/debsources/app/copyright/templates/copyright/macros.html
@@ -7,3 +7,11 @@
         {% endif %}
     {% endfor %}
 {% endmacro %}
+
+{% macro view_license(c) -%}
+    {% if c['license'] is not none %}
+      <p>According to the <a href="{{url_for('.license', path_to=(c['package']+'/'+c['version']))}}">d/copyright</a> file, <b>{{c['path']}}</b> in the package <b>{{c['package']}}</b>, version <b>{{c['version']}}</b> is licensed under <b>{{c['license']}}</b></p>
+    {% else %}
+        <p>The <a href="{{url_for('.license', path_to=(c['package']+'/'+c['version']))}}">d/copyright</a> file for the file <b>{{c['path']}}</b> in the package <b>{{c['package']}}</b>, version <b>{{c['version']}}</b> is not machine readable</p>
+    {% endif %}
+{% endmacro %}

--- a/debsources/app/copyright/views.py
+++ b/debsources/app/copyright/views.py
@@ -246,12 +246,22 @@ class SearchFileView(GeneralView):
         else:
             files = qry.get_files_by_path_package(session, path, package,
                                                   version).all()
-        if not files:
-            return dict(return_code=404,
-                        count=0,
-                        error='File not found')
-        return dict(return_code=200,
-                    count=len(files),
-                    result=[dict(checksum=res.checksum,
-                            copyright=self._license_of_files(res))
-                            for res in files])
+
+        if 'api' in request.endpoint:
+            if not files:
+                return dict(return_code=404,
+                            count=0,
+                            error='File not found')
+            return dict(return_code=200,
+                        count=len(files),
+                        result=[dict(checksum=res.checksum,
+                                copyright=self._license_of_files(res))
+                                for res in files])
+        else:
+            return dict(count=len(files),
+                        path=path,
+                        package=package,
+                        version=version,
+                        result=[dict(checksum=res.checksum,
+                                copyright=self._license_of_files(res))
+                                for res in files])

--- a/debsources/tests/test_web_cp.py
+++ b/debsources/tests/test_web_cp.py
@@ -293,6 +293,26 @@ class CopyrightTestCase(DebsourcesBaseWebTests, unittest.TestCase):
         self.assertEqual(len(rv['result'][0]['copyright']), 8)
         self.assertEqual(len(rv['result'][1]['copyright']), 2)
 
+    def test_search_filename_all(self):
+        rv = self.app.get(
+            "/copyright/file/gnubg/all/doc/gnubg/gnubg.html/").data
+        self.assertIn("File name appears 3", rv)
+
+    def test_search_filename_suite_non_existing(self):
+        rv = self.app.get(
+            "/copyright/file/gnubg/not/doc/gnubg/gnubg.html/").data
+        self.assertIn("not found", rv)
+
+    def test_search_filename_suite_filter(self):
+        rv = self.app.get("/copyright/file/gnubg/jessie/doc/gnubg/gnubg.html/",
+                          follow_redirects=True)
+        self.assertNotIn("File name appears", rv.data)
+
+    def test_search_filename(self):
+        rv = self.app.get("/copyright/file/gnubg/1.02.000-2"
+                          "/doc/gnubg/gnubg.html/", follow_redirects=True)
+        self.assertIn("GPL-3+", rv.data)
+
 
 if __name__ == '__main__':
     unittest.main(exit=False)

--- a/debsources/tests/test_web_cp.py
+++ b/debsources/tests/test_web_cp.py
@@ -159,6 +159,43 @@ class CopyrightTestCase(DebsourcesBaseWebTests, unittest.TestCase):
         self.assertLessEqual(len(rv['result']['copyright']),
                              len(rv2['result']['copyright']))
 
+    def test_checksum_view(self):
+        rv = self.app.get("/copyright/sha256/?checksum="
+                          "2e6d31a5983a91251bfae5aefa1c0a"
+                          "19d8ba3cf601d0e8a706b4cfa9661a6b8a")
+        self.assertIn("This checksum appears 12 times", rv.data)
+        self.assertIn("Most frequent license is: <i>GPL-2+</i>", rv.data)
+
+    def test_checksum_view_package_filter(self):
+        rv = self.app.get("/copyright/sha256/?checksum="
+                          "2e6d31a5983a91251bfae5aefa1c0a"
+                          "19d8ba3cf601d0e8a706b4cfa9661a6b8a&package=gnubg")
+        self.assertIn("This checksum appears 2 times", rv.data)
+        self.assertNotIn("Most common package", rv.data)
+
+    def test_checksum_view_suite_filter(self):
+        rv = self.app.get("/copyright/sha256/?checksum="
+                          "2e6d31a5983a91251bfae5aefa1c0a"
+                          "19d8ba3cf601d0e8a706b4cfa9661a6b8a&suite=latest")
+        self.assertIn("This checksum appears 8 times", rv.data)
+        rv = self.app.get("/copyright/sha256/?checksum="
+                          "2e6d31a5983a91251bfae5aefa1c0a"
+                          "19d8ba3cf601d0e8a706b4cfa9661a6b8a&suite=jessie")
+        self.assertIn("This checksum appears 7 times", rv.data)
+
+    def test_checksum_view_one_result(self):
+        rv = self.app.get("/copyright/sha256/?checksum="
+                          "2e6d31a5983a91251bfae5aefa1c0a"
+                          "19d8ba3cf601d0e8a706b4cfa9661a6b8a&package=beignet")
+        self.assertIn("This checksum appears 1 time", rv.data)
+        self.assertNotIn("<h3>Details</h3>", rv.data)
+
+    def test_checksum_404(self):
+        rv = self.app.get("/copyright/sha256/?checksum="
+                          "2e6d31a5983a91251bfae5aefa1c0a19d8"
+                          "ba3cf60d0e8a706b4cfa9661a6b8a")
+        self.assertIn("0 results", rv.data)
+
     def test_api_search_filename_package(self):
         # test package requirement
         '''rv = json.loads(self.app.get(


### PR DESCRIPTION
I wasn't sure how to reopen the PR#11 so i created a new one.
So the big change is that we run the query (to retrieve list of files associated with a checksum) only once and we slice after we take care of the pagination (so statistics don't require any other query).

Here are the routes: 

copyright/file/gnubg/1.02.000-2/doc/gnubg/gnubg.html/
copyright/file/gnubg/all/doc/gnubg/gnubg.html/
/copyright/sha256/?checksum=2e6d31a5983a91251bfae5aefa1c0a19d8ba3cf601d0e8a706b4cfa9661a6b8a
