### PR TITLE
License link

### DIFF
--- a/debsources/app/copyright/templates/copyright/license_render.inc.html
+++ b/debsources/app/copyright/templates/copyright/license_render.inc.html
@@ -31,10 +31,16 @@
       {% endif %}
       <p class='r_license'>
         <span class='r_decorate'>License: </span> 
-          {% if paragraph['license']['link'] is not none %}
-            <a href="{{ paragraph['license']['link'] }}">{{ paragraph['license']['synopsis'] }} </a>
+          {% if paragraph['license']['license'] is not none %}
+            {% for text in paragraph['license']['license'] %}
+               {% if text[1] is not none %}
+                <a href="{{ text[1] }}">{{ text[0] }} </a>
+                {% else %}
+                  {{text[0]}}
+               {% endif %}
+            {% endfor %}
           {% else %}
-            {{ paragraph['license']['synopsis'] }}
+            {{ paragraph['license']['license'] }}
           {% endif %}
       </p>
       {% if paragraph['license']['text'] is not none %}

--- a/debsources/app/copyright/templates/copyright/license_render.inc.html
+++ b/debsources/app/copyright/templates/copyright/license_render.inc.html
@@ -1,71 +1,64 @@
-{% import "copyright/macros.html" as macro %}
+{%- import "copyright/macros.html" as macro %}
 <div class='r_header'><h2>Header</h2>
-  {% for h in header %}
-    {% if h == 'Source' or h == 'Format' %}
+  {%- for h in header %}
+    {%- if h == 'Source' or h == 'Format' %}
       <p><span class='r_decorate'> {{ h }}: </span> <a href='{{ header[h] }}'>{{ header[h] }}</a></p>
-    {% else %}
+    {%- else %}
       <p><span class='r_decorate'> {{ h }}: </span> {{ header[h] }}</p>
-    {% endif %}
-  {% endfor %}
+    {%- endif %}
+  {%- endfor %}
 </div>
 <div class='r_files'><h2>Files</h2>
-  {% for paragraph in files %}
+  {%- for paragraph in files %}
     <p class='r_glob'> 
-      {% for file in paragraph['globs'] %}
-        {% if file['url'] is not none %}
+      {%- for file in paragraph['globs'] %}
+        {%- if file['url'] is not none %}
           <a href="{{ file['url'] }}">{{ file['files'] }}</a> 
-        {% else %}
+        {%- else %}
           {{ file['files'] }}
-        {% endif %}
-      {% endfor %}
+        {%- endif %}
+      {%- endfor %}
     </p>
     <div class='r_files_info'>
       <div class="r_copyright">
         <span class='r_decorate'>Copyright: </span>
         <pre> {{ paragraph['copyright'] }}</pre>
       </div>
-      {% if paragraph['comment'] is not none %}
+      {%- if paragraph['comment'] is not none %}
         <p class='r_comment'>
           <span class='r_decorate'>Comment: </span> {{ macro.match_d_license(paragraph['comment']) }}
         </p>
-      {% endif %}
+      {%- endif %}
       <p class='r_license'>
         <span class='r_decorate'>License: </span> 
-          {% if paragraph['license']['license'] is not none %}
-            {% for text in paragraph['license']['license'] %}
-               {% if text[1] is not none %}
-                <a href="{{ text[1] }}">{{ text[0] }} </a>
-                {% else %}
-                  {{text[0]}}
-               {% endif %}
-            {% endfor %}
-          {% else %}
-            {{ paragraph['license']['license'] }}
-          {% endif %}
+          {%- if paragraph['license']['license'] is not none %}
+            {%- for text in paragraph['license']['license'] %}
+               {%- if text[1] is not none %} <a href="{{ text[1] }}">{{ text[0] }}</a>{%- else %}{{ text[0] }}{%- endif %}
+            {%- endfor %}
+          {%- else %}{{ paragraph['license']['license'] }}{%- endif %}
       </p>
-      {% if paragraph['license']['text'] is not none %}
+      {%- if paragraph['license']['text'] is not none %}
         <pre class='r_synopsis'>{{ paragraph['license']['text'] }} </pre>
-      {% endif %}
+      {%- endif %}
     </div>
-  {% endfor %}
+  {%- endfor %}
 </div>
 <div class='r_licenses'><h2>Licenses</h2>
-  {% for license in licenses %}
+  {%- for license in licenses %}
     <div class='license'>
       <p class='r_license' id='license-{{ loop.index0 }}'>
         <span class='r_decorate'>License: </span> 
-        {% if license['link'] is not none %}
+        {%- if license['link'] is not none %}
             <a href="{{ license['link'] }}"> {{ license['synopsis'] }}</a> 
-          {% else %}
-            {{ license['synopsis'] }}
-        {% endif %}
+          {%- else %}{{ license['synopsis'] }}
+        {%- endif %}
       </p>
     </div>
     <div id="desc-{{ loop.index0 }}">
       <pre class='r_synopsis'>{{ license['text'] }} </pre>
-      {% if license['comment'] is not none %}
+      {%- if license['comment'] is not none %}
         <p class='r_l_comment'><span class='r_decorate'>Comment: </span>{{ macro.match_d_license(license['comment']) }}</p>
-      {% endif %}
+      {%- endif %}
     </div>
-  {% endfor %}
+  {%- endfor %}
 </div>

--- a/debsources/app/copyright/templates/copyright/macros.html
+++ b/debsources/app/copyright/templates/copyright/macros.html
@@ -1,18 +1,22 @@
-{% extends "sources/_macros.html" %}
-{% macro match_d_license(comment) -%}
-    {% for word in comment.split() %}
-        {% if '/usr/share/common-licenses/' in word %}
-            {% set path_dict = word.split('/usr/share/common-licenses/') %}
-            {% set comment = comment|replace(word, "<a href='http://sources.debian.net/src/base-files/latest/licenses/" + path_dict[1] + "'>" + word + "</a>" ) %}
-        {{comment|safe}}
-        {% endif %}
-    {% endfor %}
-{% endmacro %}
+{%- extends "sources/_macros.html" %}
+{%- macro match_d_license(comment) -%}
+    {%- if '/usr/share/common-licenses/' in comment %}
+        {%- for word in comment.split() %}
+            {%- if '/usr/share/common-licenses/' in word %}
+                {%- set path_dict = word.split('/usr/share/common-licenses/') %}
+                {%- set comment = comment|replace(word, "<a href='http://sources.debian.net/src/base-files/latest/licenses/" + path_dict[1] + "'>" + word + "</a>" ) %}
+            {{comment|safe}}
+            {%- endif %}
+        {%- endfor %}
+    {%- else %}
+        {{ comment }}
+    {%- endif %}
+{%- endmacro %}
 
-{% macro view_license(c) -%}
-    {% if c['license'] is not none %}
+{%- macro view_license(c) -%}
+    {%- if c['license'] is not none %}
       <p>According to the <a href="{{url_for('.license', path_to=(c['package']+'/'+c['version']))}}">d/copyright</a> file, <b>{{c['path']}}</b> in the package <b>{{c['package']}}</b>, version <b>{{c['version']}}</b> is licensed under <b>{{c['license']}}</b></p>
-    {% else %}
+    {%- else %}
         <p>The <a href="{{url_for('.license', path_to=(c['package']+'/'+c['version']))}}">d/copyright</a> file for the file <b>{{c['path']}}</b> in the package <b>{{c['package']}}</b>, version <b>{{c['version']}}</b> is not machine readable</p>
-    {% endif %}
-{% endmacro %}
+    {%- endif %}
+{%- endmacro %}

--- a/debsources/app/infobox.py
+++ b/debsources/app/infobox.py
@@ -11,11 +11,11 @@
 
 from __future__ import absolute_import
 
-
 PTS_PREFIX = "https://tracker.debian.org/pkg/"
 # move this to configuration file?
 # it would add a dependence layer with app.config
 
+from flask import url_for
 
 from debsources.models import (
     PackageName, Package, Suite, SlocCount, Metric, Ctag)
@@ -114,6 +114,13 @@ class Infobox(object):
 
         return ctags_count
 
+    def _get_license_link(self):
+        """ Returns the license link in the copyright BP
+
+        """
+        return url_for('copyright.license',
+                       path_to=self.package + '/' + self.version)
+
     def get_infos(self):
         """
         Retrieves information about the version of a package:
@@ -145,5 +152,7 @@ class Infobox(object):
         pkg_infos["pts_link"] = self._get_pts_link()
 
         pkg_infos["ctags_count"] = self._get_ctags_count()
+
+        pkg_infos['license'] = self._get_license_link()
 
         return pkg_infos

--- a/debsources/app/sources/templates/sources/_macros_infobox.html
+++ b/debsources/app/sources/templates/sources/_macros_infobox.html
@@ -33,6 +33,7 @@
     <em>{{ package }} {{ version }}</em>
     {% endif %}
     <ul>
+      <li><a href="{{ pkg_infos['license'] }}">view license information</a></li>
       <li>links:
   <a href="{{ pkg_infos['pts_link'] }}"><abbr title="Debian Package Tracking
                  System">PTS</abbr></a>{% if pkg_infos['vcs_browser'] %},

--- a/debsources/tests/test_web_cp.py
+++ b/debsources/tests/test_web_cp.py
@@ -313,6 +313,16 @@ class CopyrightTestCase(DebsourcesBaseWebTests, unittest.TestCase):
                           "/doc/gnubg/gnubg.html/", follow_redirects=True)
         self.assertIn("GPL-3+", rv.data)
 
+    def test_synopsis_parsing(self):
+        rv = self.app.get("/copyright/license/gnubg/1.02.000-2/")
+        self.assertIn("<a href=\"#license-0\">FSF-configure</a>", rv.data)
+        # Test separating by ',' and, or and create correct links
+        synopsis = "<a href=\"#license-0\">FSF-configure</a>, and  " \
+                   "<a href=\"http://opensource.org/licenses/GPL-2.0\">GPL-2+" \
+                   " with Libtool exception</a> or  <a href=\"http://opensou" \
+                   "rce.org/licenses/GPL-3.0\">GPL-3+</a>"
+        self.assertIn(synopsis, rv.data)
+
 
 if __name__ == '__main__':
     unittest.main(exit=False)

--- a/debsources/tests/test_webapp.py
+++ b/debsources/tests/test_webapp.py
@@ -501,6 +501,8 @@ class DebsourcesTestCase(DebsourcesBaseWebTests, unittest.TestCase):
         self.assertEqual(rv["pkg_infos"]["pts_link"],
                          "https://tracker.debian.org/pkg/libcaca")
         self.assertEqual(rv["pkg_infos"]["ctags_count"], 3145)
+        self.assertEqual(rv["pkg_infos"]["license"],
+                         '/copyright/license/libcaca/0.99.beta17-1/')
 
     def test_pkg_infobox_embed(self):
         rv = self.app.get('/embed/pkginfo/libcaca/0.99.beta17-1/')


### PR DESCRIPTION
- I added a link in the infobox which points at the license in the copyright BP.
- Fixed the issue with the license synopsis. The modifications now allow us to parse the synopsis splitting by the separators 'and', 'or', ',' then create links to the standard licenses and/or license text inside the License if they exist.

Example:
FSF-unlimited or GPL-2
for FSF-unlimited the link will points to the text in the license paragraphs (inside the page if such a paragraph exists) and for GPL-2 a link to opensource.org
