### PR TITLE
Propagate bp in search

### DIFF
--- a/debsources/app/copyright/routes.py
+++ b/debsources/app/copyright/routes.py
@@ -17,7 +17,7 @@ from flask import jsonify
 from ..helper import bind_render
 from . import bp_copyright
 from ..views import (IndexView, PrefixView, ListPackagesView, ErrorHandler,
-                     Ping, PackageVersionsView, DocView, AboutView)
+                     Ping, PackageVersionsView, DocView, AboutView, SearchView)
 from .views import LicenseView, ChecksumLicenseView, SearchFileView
 
 
@@ -188,3 +188,33 @@ bp_copyright.add_url_rule(
         'about',
         render_func=bind_render('about.html'),
         err_func=ErrorHandler('sources'),))
+
+
+# SEARCHVIEW
+bp_copyright.add_url_rule(
+    '/search/',
+    view_func=SearchView.as_view(
+        'recv_search',
+        render_func=bind_render('copyright/index.html'),
+        err_func=ErrorHandler('copyright'),
+        recv_search=True),
+    methods=['GET', 'POST'])
+
+
+bp_copyright.add_url_rule(
+    '/search/<query>/',
+    view_func=SearchView.as_view(
+        'search',
+        render_func=bind_render('search.html'),
+        err_func=ErrorHandler('copyright'),
+        get_objects='query',))
+
+
+# api
+bp_copyright.add_url_rule(
+    '/api/search/<query>/',
+    view_func=SearchView.as_view(
+        'api_search',
+        render_func=jsonify,
+        err_func=ErrorHandler(mode='json'),
+        get_objects='query'))

--- a/debsources/app/copyright/templates/copyright/index.html
+++ b/debsources/app/copyright/templates/copyright/index.html
@@ -29,7 +29,6 @@
       <p><strong>Browse</strong> by prefix</p>
       <p>{{ macros.render_packages_prefixes(packages_prefixes) }}</p>
     </td>
-    <!--
     <td id="search">
       <p><strong>Search</strong></p>
       <ul style="list-style-type: none">
@@ -37,7 +36,7 @@
 	  {{ macros.searchform(searchform, value=query, display="inline", size="25", autofocus=True, id="query-2") }}
 	</li>
       </ul>
-    </td>-->
+    </td>
   </tr>
 </table>
 

--- a/debsources/app/sources/routes.py
+++ b/debsources/app/sources/routes.py
@@ -169,7 +169,7 @@ bp_sources.add_url_rule(
     '/search/<query>/',
     view_func=SearchView.as_view(
         'search',
-        render_func=bind_render('sources/search.html'),
+        render_func=bind_render('search.html'),
         err_func=ErrorHandler('sources'),
         get_objects='query',))
 

--- a/debsources/app/templates/_macros.html
+++ b/debsources/app/templates/_macros.html
@@ -33,7 +33,7 @@ https://pythonhosted.org/Flask-SQLAlchemy/api.html#flask.ext.sqlalchemy.Paginati
 {%- endmacro %}
 
 {% macro searchform(form, display="block") -%}
-  <form action="{{ url_for('sources.recv_search') }}" name="searchform"
+  <form action="{{ url_for('.recv_search') }}" name="searchform"
         method="post" style="display: {{ display }};">
       {{ form.query(**kwargs) }}
     {% for error in form.errors.query %}

--- a/debsources/app/templates/search.html
+++ b/debsources/app/templates/search.html
@@ -6,7 +6,7 @@
 #}
 {# copied from templates/search.html #}
 
-{% extends "sources/base.html" %}
+{% extends name+"/base.html" %}
 
 {% block title %}Search: {{ query }}{% endblock %}
 

--- a/debsources/app/views.py
+++ b/debsources/app/views.py
@@ -311,22 +311,14 @@ class SearchView(GeneralView):
         suite = suite.lower()
         if suite == "all":
             suite = ""
-        # if suite is not specified
-        if not suite:
-            try:
-                exact_matching = qry.get_pkg_by_name(session, query)
 
-                other_results = qry.get_pkg_by_similar_name(session, query)
-            except Exception as e:
-                raise Http500Error(e)  # db problem, ...
-        else:
-            try:
-                exact_matching = qry.get_pkg_by_name(session, query, suite)
+        try:
+            exact_matching = qry.get_pkg_by_name(session, query, suite)
 
-                other_results = qry.get_pkg_by_similar_name(session,
-                                                            query, suite)
-            except Exception as e:
-                raise Http500Error(e)  # db problem, ...
+            other_results = qry.get_pkg_by_similar_name(session,
+                                                        query, suite)
+        except Exception as e:
+            raise Http500Error(e)  # db problem, ...
 
         if exact_matching is not None:
             exact_matching = exact_matching.to_dict()


### PR DESCRIPTION
- When using the package search (at the top bar) inside the copyright BP the results are redirected inside the copyright BP
- Enable the search form in the index of the copyright BP (same search form that exists in the sources BP)
