### PR TITLE
Patch tracker blueprint init

### DIFF
--- a/contrib/docker/config.ini
+++ b/contrib/docker/config.ini
@@ -87,6 +87,9 @@ blueprint_copyright: true
 # whether to enable blueprint sources
 blueprint_sources: true
 
+# whether to enable blueprint patches
+blueprint_patches: true
+
 # the url for sources, either subdomain or url_prefix
 sources_url: sources.debian.net
 

--- a/debsources/app/app_factory.py
+++ b/debsources/app/app_factory.py
@@ -63,6 +63,11 @@ class AppWrapper(object):
             # add a url-prefix
             self.app.register_blueprint(bp_copyright,
                                         url_prefix='/copyright')
+        if self.app.config.get('BLUEPRINT_PATCHES'):
+            from debsources.app.patches import bp_patches
+            # add a url-prefix
+            self.app.register_blueprint(bp_patches,
+                                        url_prefix='/patches')
 
         if self.app.config.get('BLUEPRINT_SOURCES'):
             from debsources.app.sources import bp_sources

--- a/debsources/app/patches/__init__.py
+++ b/debsources/app/patches/__init__.py
@@ -1,0 +1,23 @@
+# Copyright (C) 2015  The Debsources developers <info@sources.debian.net>.
+# See the AUTHORS file at the top-level directory of this distribution and at
+# https://anonscm.debian.org/gitweb/?p=qa/debsources.git;a=blob;f=AUTHORS;hb=HEAD
+#
+# This file is part of Debsources. Debsources is free software: you can
+# redistribute it and/or modify it under the terms of the GNU Affero General
+# Public License as published by the Free Software Foundation, either version 3
+# of the License, or (at your option) any later version.  For more information
+# see the COPYING file at the top-level directory of this distribution and at
+# https://anonscm.debian.org/gitweb/?p=qa/debsources.git;a=blob;f=COPYING;hb=HEAD
+
+from __future__ import absolute_import
+
+from flask import Blueprint
+
+# naming rule: bp_{dirname}
+bp_patches = Blueprint('patches',
+                       __name__,
+                       template_folder='templates',
+                       static_url_path='/static/patches',
+                       static_folder='static')
+
+from . import routes  # NOQA

--- a/debsources/app/patches/routes.py
+++ b/debsources/app/patches/routes.py
@@ -1,0 +1,22 @@
+# Copyright (C) 2015  The Debsources developers <info@sources.debian.net>.
+# See the AUTHORS file at the top-level directory of this distribution and at
+# https://anonscm.debian.org/gitweb/?p=qa/debsources.git;a=blob;f=AUTHORS;hb=HEAD
+#
+# This file is part of Debsources. Debsources is free software: you can
+# redistribute it and/or modify it under the terms of the GNU Affero General
+# Public License as published by the Free Software Foundation, either version 3
+# of the License, or (at your option) any later version.  For more information
+# see the COPYING file at the top-level directory of this distribution and at
+# https://anonscm.debian.org/gitweb/?p=qa/debsources.git;a=blob;f=COPYING;hb=HEAD
+
+
+from __future__ import absolute_import
+
+from . import bp_patches
+
+from .views import IndexView
+
+bp_patches.add_url_rule(
+    '/',
+    view_func=IndexView.as_view(
+        'index'))

--- a/debsources/app/patches/routes.py
+++ b/debsources/app/patches/routes.py
@@ -18,7 +18,7 @@ from . import bp_patches
 
 from ..helper import bind_render
 from ..views import (IndexView, Ping, PrefixView, ErrorHandler,
-                     ListPackagesView, PackageVersionsView)
+                     ListPackagesView, PackageVersionsView, SearchView)
 from .views import SummaryView
 
 
@@ -114,3 +114,32 @@ bp_patches.add_url_rule(
         'summary',
         render_func=bind_render('patches/summary.html'),
         err_func=ErrorHandler('patches')))
+
+# SEARCHVIEW
+bp_patches.add_url_rule(
+    '/search/',
+    view_func=SearchView.as_view(
+        'recv_search',
+        render_func=bind_render('patches/index.html'),
+        err_func=ErrorHandler('patches'),
+        recv_search=True),
+    methods=['GET', 'POST'])
+
+
+bp_patches.add_url_rule(
+    '/search/<query>/',
+    view_func=SearchView.as_view(
+        'search',
+        render_func=bind_render('search.html'),
+        err_func=ErrorHandler('patches'),
+        get_objects='query',))
+
+
+# api
+bp_patches.add_url_rule(
+    '/api/search/<query>/',
+    view_func=SearchView.as_view(
+        'api_search',
+        render_func=jsonify,
+        err_func=ErrorHandler(mode='json'),
+        get_objects='query'))

--- a/debsources/app/patches/templates/patches/index.html
+++ b/debsources/app/patches/templates/patches/index.html
@@ -29,7 +29,6 @@
       <p><strong>Browse</strong> by prefix</p>
       <p>{{ macros.render_packages_prefixes(packages_prefixes) }}</p>
     </td>
-    <!--
     <td id="search">
       <p><strong>Search</strong></p>
       <ul style="list-style-type: none">
@@ -37,7 +36,7 @@
 	  {{ macros.searchform(searchform, value=query, display="inline", size="25", autofocus=True, id="query-2") }}
 	</li>
       </ul>
-    </td>-->
+    </td>
   </tr>
 </table>
 

--- a/debsources/app/patches/templates/patches/index.html
+++ b/debsources/app/patches/templates/patches/index.html
@@ -1,0 +1,59 @@
+{#
+  Copyright (C) 2015  The Debsources developers <info@sources.debian.net>.
+  See the AUTHORS file at the top-level directory of this distribution and at
+  https://anonscm.debian.org/gitweb/?p=qa/debsources.git;a=blob;f=AUTHORS;hb=HEAD
+  License: GNU Affero General Public License, version 3 or above.
+#}
+{# copied from templates/index.html #}
+{% extends name+"/base.html" %}
+
+{% block title %}Debian Sources{% endblock %}
+
+{% block breadcrumbs %}{% endblock %}
+
+{% block content %}
+
+<div id="indexmenu">
+
+<h1 class="h1mainpage">{{ self.title() }}</h1>
+<h3><em>All Debian patch are belong to us</em> &emsp;
+  <small>&mdash; Anonymous</small>
+  <sup><a href="https://en.wikipedia.org/wiki/All_your_base_are_belong_to_us"><span style="font-family: monospace; color: black;">[^]</span></a></sup>
+</h3>
+<p>Browse through the patches applied in
+  <a href="https://www.debian.org">Debian</a> packages.
+  <a href="{{ url_for(name+'.doc_overview') }}">Read more…</a></p>
+<table>
+  <tr>
+    <td id="browse">
+      <p><strong>Browse</strong> by prefix</p>
+      <p>{{ macros.render_packages_prefixes(packages_prefixes) }}</p>
+    </td>
+    <!--
+    <td id="search">
+      <p><strong>Search</strong></p>
+      <ul style="list-style-type: none">
+  <li>by <em>package name</em>:<br />
+	  {{ macros.searchform(searchform, value=query, display="inline", size="25", autofocus=True, id="query-2") }}
+	</li>
+      </ul>
+    </td>-->
+  </tr>
+</table>
+
+</div>
+
+{% if news -%}
+<h3><a name="news">News</a></h3>
+{{ news|safe }}
+{% endif %}
+
+{% endblock %}
+
+{# show the background debian image #}
+{% block bg_wrapper %}
+<div id="bg-wrapper" style="background-image: url('{{ url_for('static', filename='img/debsources.png') }}');">
+  <div id="content">{{ self.content() }}</div>
+  <footer id="footer">{{ self.footer() }}</footer>
+</div>
+{% endblock %}

--- a/debsources/app/patches/templates/patches/macros.html
+++ b/debsources/app/patches/templates/patches/macros.html
@@ -1,0 +1,2 @@
+{% extends "sources/_macros.html" %}
+

--- a/debsources/app/patches/templates/patches/package.html
+++ b/debsources/app/patches/templates/patches/package.html
@@ -1,0 +1,23 @@
+{#
+  Copyright (C) 2015  The Debsources developers <info@sources.debian.net>.
+  See the AUTHORS file at the top-level directory of this distribution and at
+  https://anonscm.debian.org/gitweb/?p=qa/debsources.git;a=blob;f=AUTHORS;hb=HEAD
+  License: GNU Affero General Public License, version 3 or above.
+#}
+{# copied from templates/source_base.html #}
+{% extends "sources/source_base.html" %}
+
+{% block head %}
+{{ super() }}
+<link rel="stylesheet" type="text/css"
+      href="{{ url_for('sources.static', filename='css/source_folder.css') }}" />
+{% endblock %}
+
+{% block title %}Package: {{ package }}{% endblock %}
+{% block source_content %}
+<h2>{{ self.title() }}</h2>
+{{ macros.show_suite(suite) }}
+
+{{ macros.show_versions(versions, path, '.summary', config['ICONS_FOLDER'])}}
+
+{% endblock %}

--- a/debsources/app/patches/templates/patches/summary.html
+++ b/debsources/app/patches/templates/patches/summary.html
@@ -1,0 +1,21 @@
+{#
+  Copyright (C) 2015  The Debsources developers <info@sources.debian.net>.
+  See the AUTHORS file at the top-level directory of this distribution and at
+  https://anonscm.debian.org/gitweb/?p=qa/debsources.git;a=blob;f=AUTHORS;hb=HEAD
+  License: GNU Affero General Public License, version 3 or above.
+#}
+{# copied from templates/source_base.html #}
+{% extends name+"/base.html" %}
+
+{% block head %}
+{{ super() }} 
+{% endblock %}
+{% block breadcrumbs %} Patches / <a href="{{ url_for('.versions', packagename=package) }}">{{ package }}</a> 
+            /{{ version }}
+{% endblock %}
+{% block title %}Package: {{ package }}{% endblock %}
+{% block content %}
+<h2>{{ self.title() }} / {{ version }}</h2>
+
+Summary for {{ package }} / {{ version }}
+{% endblock %}

--- a/debsources/app/patches/views.py
+++ b/debsources/app/patches/views.py
@@ -11,11 +11,15 @@
 
 from __future__ import absolute_import
 
-from flask.views import View
+from ..views import GeneralView
 
 
-# this is just a placeholder
-class IndexView(View):
+class SummaryView(GeneralView):
 
-    def dispatch_request(self):
-        return "Hello World"
+    def get_objects(self, path_to):
+        path_dict = path_to.split('/')
+        package = path_dict[0]
+        version = path_dict[1]
+
+        return dict(package=package,
+                    version=version)

--- a/debsources/app/patches/views.py
+++ b/debsources/app/patches/views.py
@@ -1,0 +1,21 @@
+# Copyright (C) 2015  The Debsources developers <info@sources.debian.net>.
+# See the AUTHORS file at the top-level directory of this distribution and at
+# https://anonscm.debian.org/gitweb/?p=qa/debsources.git;a=blob;f=AUTHORS;hb=HEAD
+#
+# This file is part of Debsources. Debsources is free software: you can
+# redistribute it and/or modify it under the terms of the GNU Affero General
+# Public License as published by the Free Software Foundation, either version 3
+# of the License, or (at your option) any later version.  For more information
+# see the COPYING file at the top-level directory of this distribution and at
+# https://anonscm.debian.org/gitweb/?p=qa/debsources.git;a=blob;f=COPYING;hb=HEAD
+
+from __future__ import absolute_import
+
+from flask.views import View
+
+
+# this is just a placeholder
+class IndexView(View):
+
+    def dispatch_request(self):
+        return "Hello World"

--- a/debsources/app/patches/views.py
+++ b/debsources/app/patches/views.py
@@ -11,6 +11,8 @@
 
 from __future__ import absolute_import
 
+from flask import request
+
 from ..views import GeneralView
 
 
@@ -20,6 +22,21 @@ class SummaryView(GeneralView):
         path_dict = path_to.split('/')
         package = path_dict[0]
         version = path_dict[1]
+
+        path = '/'.join(path_dict[2:])
+
+        if version == "latest":  # we search the latest available version
+            return self._handle_latest_version(request.endpoint,
+                                               package, path)
+
+        versions = self.handle_versions(version, package, path)
+        if versions:
+            redirect_url_parts = [package, versions[-1]]
+            if path:
+                redirect_url_parts.append(path)
+            redirect_url = '/'.join(redirect_url_parts)
+            return self._redirect_to_url(request.endpoint,
+                                         redirect_url, redirect_code=302)
 
         return dict(package=package,
                     version=version)

--- a/debsources/app/views.py
+++ b/debsources/app/views.py
@@ -529,9 +529,10 @@ class PackageVersionsView(GeneralView):
             endpoint = '.source'
         elif request.blueprint == 'copyright':
             endpoint = '.license'
+        elif request.blueprint == 'patches':
+            endpoint = '.summary'
 
         pathl = qry.location_get_path_links(endpoint, packagename)
-
         return dict(type="package",
                     package=packagename,
                     versions=versions_w_suites,

--- a/debsources/tests/test_web_patches.py
+++ b/debsources/tests/test_web_patches.py
@@ -1,0 +1,75 @@
+# Copyright (C) 2015  The Debsources developers <info@sources.debian.net>.
+# See the AUTHORS file at the top-level directory of this distribution and at
+# https://anonscm.debian.org/gitweb/?p=qa/debsources.git;a=blob;f=AUTHORS;hb=HEAD
+#
+# This file is part of Debsources. Debsources is free software: you can
+# redistribute it and/or modify it under the terms of the GNU Affero General
+# Public License as published by the Free Software Foundation, either version 3
+# of the License, or (at your option) any later version.  For more information
+# see the COPYING file at the top-level directory of this distribution and at
+# https://anonscm.debian.org/gitweb/?p=qa/debsources.git;a=blob;f=COPYING;hb=HEAD
+
+from __future__ import absolute_import
+
+import json
+import unittest
+
+from nose.plugins.attrib import attr
+
+from debsources.tests.test_webapp import DebsourcesBaseWebTests
+
+
+@attr('patches')
+class CopyrightTestCase(DebsourcesBaseWebTests, unittest.TestCase):
+
+    def test_api_ping(self):
+        rv = json.loads(self.app.get('/patches/api/ping/').data)
+        self.assertEqual(rv["status"], "ok")
+        self.assertEqual(rv["http_status_code"], 200)
+
+    def test_api_packages_list(self):
+        rv = json.loads(
+            self.app.get('/patches/api/list/').data)
+        self.assertIn({'name': "ocaml-curses"}, rv['packages'])
+        self.assertEqual(len(rv['packages']), 18)
+
+    def test_api_by_prefix(self):
+        rv = json.loads(
+            self.app.get('/patches/api/prefix/o/').data)
+        self.assertIn({'name': "ocaml-curses"}, rv['packages'])
+        # suite specified
+        rv = json.loads(
+            self.app.get('/patches/api/prefix/o/?suite=wheezy').data)
+        self.assertIn({'name': "ocaml-curses"}, rv['packages'])
+        # a non-existing suite specified
+        rv = json.loads(self.app.get(
+            '/patches/api/prefix/libc/?suite=non-existing').data)
+        self.assertEqual([], rv['packages'])
+        # special suite name "all" is specified
+        rv = json.loads(
+            self.app.get('/patches/api/prefix/libc/?suite=all').data)
+        self.assertIn({'name': "libcaca"}, rv['packages'])
+
+    def test_by_prefix(self):
+        rv = self.app.get('/patches/prefix/libc/')
+        self.assertIn("/summary/libcaca", rv.data)
+        # suite specified
+        rv = self.app.get('/patches/prefix/libc/?suite=squeeze')
+        self.assertIn("/summary/libcaca", rv.data)
+        # a non-existing suite specified
+        rv = self.app.get(
+            '/patches/prefix/libc/?suite=non-existing')
+        self.assertNotIn("/summary/libcaca", rv.data)
+        # special suite name "all" is specified
+        rv = self.app.get(
+            '/patches/prefix/libc/?suite=all')
+        self.assertIn("/summary/libcaca", rv.data)
+
+    def test_latest(self):
+        rv = self.app.get('/patches/summary/gnubg/latest/',
+                          follow_redirects=True)
+        self.assertIn("Package: gnubg / 1.02.000-2", rv.data)
+
+
+if __name__ == '__main__':
+    unittest.main(exit=False)

--- a/etc/config.ini
+++ b/etc/config.ini
@@ -94,6 +94,9 @@ blueprint_copyright: true
 # whether to enable blueprint sources
 blueprint_sources: true
 
+# whether to enable blueprint patches
+blueprint_patches: true
+
 # the url for sources, either subdomain or url_prefix
 sources_url: sources.debian.net
 

--- a/etc/config.travis.ini
+++ b/etc/config.travis.ini
@@ -88,6 +88,9 @@ blueprint_copyright: true
 # whether to enable blueprint sources
 blueprint_sources: true
 
+# whether to enable blueprint patches
+blueprint_patches: true
+
 # the url for sources, either subdomain or url_prefix
 sources_url: sources.debian.net
 


### PR DESCRIPTION
This BP 
- creates the skeleton BP for the patch tracker
- then the navigation (by prefix, list of packages, browse versions)
- and adds basic navigation tests in the test suite for the patch tracker.

(+ some changes in the config files for the patch tracker)
