### PR TITLE
Summary and patch view

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ notifications:
 before_install:
   - pwd
   - sudo apt-get update -qq
-  - sudo apt-get install -y tango-icon-theme debmirror exuberant-ctags sloccount dpkg-dev libapt-pkg-dev
+  - sudo apt-get install -y tango-icon-theme debmirror exuberant-ctags sloccount dpkg-dev libapt-pkg-dev diffstat
   - git clone https://github.com/file/file.git ../file && pip install -e ../file/python
   - pip install https://launchpad.net/python-apt/main/0.7.8/+download/python-apt-0.8.5.tar.gz
   - pip install flake8

--- a/README
+++ b/README
@@ -54,6 +54,7 @@ Debian packages:
 - python-flup (for FastCGI deployment)
 - python-magic
 - tango-icon-theme
+- diffstat
 
 
 Infrastructure

--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -28,7 +28,8 @@ RUN apt-get install -y \
     python-nose \
     python-nose2-cov \
     python-flaskext.wtf \
-    dpkg-dev
+    dpkg-dev \
+    diffstat
 
 # dev tools
 RUN apt-get install -y lynx emacs

--- a/debsources/app/patches/routes.py
+++ b/debsources/app/patches/routes.py
@@ -19,7 +19,7 @@ from . import bp_patches
 from ..helper import bind_render
 from ..views import (IndexView, Ping, PrefixView, ErrorHandler,
                      ListPackagesView, PackageVersionsView, SearchView)
-from .views import SummaryView
+from .views import SummaryView, PatchView
 
 
 # context vars
@@ -103,7 +103,7 @@ bp_patches.add_url_rule(
         render_func=jsonify,
         err_func=ErrorHandler(mode='json')))
 
-# PATCHVIEW
+# SUMMARYVIEW
 # Why not summary/<string:packagename>/<string:version>
 # Because then the patches blueprint must have its own show versions in the
 # macros since the other two blueprints will have a path_to parameter instead
@@ -143,3 +143,11 @@ bp_patches.add_url_rule(
         render_func=jsonify,
         err_func=ErrorHandler(mode='json'),
         get_objects='query'))
+
+# PATCHVIEW
+bp_patches.add_url_rule(
+    '/patch/<path:path_to>/',
+    view_func=PatchView.as_view(
+        'patch',
+        render_func=bind_render('patches/patch.html'),
+        err_func=ErrorHandler('patches')))

--- a/debsources/app/patches/templates/patches/404_suggestions.html
+++ b/debsources/app/patches/templates/patches/404_suggestions.html
@@ -1,0 +1,17 @@
+{#
+  Copyright (C) 2015  The Debsources developers <info@sources.debian.net>.
+  See the AUTHORS file at the top-level directory of this distribution and at
+  https://anonscm.debian.org/gitweb/?p=qa/debsources.git;a=blob;f=AUTHORS;hb=HEAD
+  License: GNU Affero General Public License, version 3 or above.
+#}
+
+<p>The specific version of the package you requested doesn't exist,
+but other versions of this package are available in the database.
+The license you are looking for might exist in one of the following
+versions:
+<ul>
+{% for s in suggestions %}
+  <li><a href="{{ url_for('.summary', path_to=s) }}">{{ s }}</a></li>
+{% endfor %}
+</ul>
+</p>

--- a/debsources/app/patches/templates/patches/patch.html
+++ b/debsources/app/patches/templates/patches/patch.html
@@ -1,0 +1,30 @@
+{#
+  Copyright (C) 2015  The Debsources developers <info@sources.debian.net>.
+  See the AUTHORS file at the top-level directory of this distribution and at
+  https://anonscm.debian.org/gitweb/?p=qa/debsources.git;a=blob;f=AUTHORS;hb=HEAD
+  License: GNU Affero General Public License, version 3 or above.
+#}
+{% extends name+"/base.html" %}
+
+{% block head %}
+{{ super() }}
+  <script src="{{ url_for('static', filename='javascript/debsources.js') }}"></script>
+  <link rel="stylesheet" type="text/css"
+        href="{{ url_for('sources.static', filename='css/source_file.css') }}" />
+  <link rel="stylesheet"
+        href="{{ config.HIGHLIGHT_JS_FOLDER }}/styles/{{ config.HIGHLIGHT_STYLE }}.css">
+  <script src="{{ config.HIGHLIGHT_JS_FOLDER }}/highlight.min.js"></script> 
+{% endblock %}
+{% block breadcrumbs %} Patch / <a href="{{ url_for('.versions', packagename=package) }}">{{ package }}</a> / <a href="{{ url_for('.summary', path_to=path) }}">{{ version }}</a>
+{% endblock %}
+{% block title %}Package: {{ package }}{% endblock %}
+{% block content %}
+<h2>{{ self.title() }} / {{ version }}</h2>
+
+{% include "source_file_code.inc.html" %}
+<script type="text/javascript">
+  debsources.source_file();
+  hljs.highlightBlock(document.getElementById('sourcecode'))
+
+</script>
+{% endblock %}

--- a/debsources/app/patches/templates/patches/summary.html
+++ b/debsources/app/patches/templates/patches/summary.html
@@ -17,5 +17,43 @@
 {% block content %}
 <h2>{{ self.title() }} / {{ version }}</h2>
 
-Summary for {{ package }} / {{ version }}
+<h3>Metadata</h3>
+<table>
+ <tr class="head">
+    <th>Package</th>
+    <th>Version</th>
+    <th>Patches format</th>
+  </tr>
+  <tr>
+    <td>{{ package }}</td>
+    <td>{{ version }}</td>
+    <td>{{ format }}</td>
+  </tr>
+</table>
+
+{% if format.rstrip() != '3.0 (quilt)' %}
+  <p>The format of the patches in the package is not yet supported! </p>
+{% else %}
+  {% if patches == 0 %}
+    <p>This package has no patches.</p>
+  {% else %}
+    <h3>Patch series</h3>
+      <table>
+       <tr class="head">
+          <th>Patch</th>
+          <th>File delta</th>
+          <th>View</th>
+          <th>Download</th>
+        </tr>
+        {% for patch in series %}
+        <tr>
+          <td>{{ patch.replace('.patch', '').replace('-', ' ') }}</td>
+          <td><pre>{{ patches_info[patch]['summary']}}</pre></td>
+          <td><a href="{{ url_for('.patch', path_to=path + '/' +patch.rstrip())}}">View</a></td>
+          <td><a href="{{ patches_info[patch]['download'] }}">download</a></td>
+        </tr>
+        {% endfor %}
+      </table>
+  {% endif %}
+{% endif %}
 {% endblock %}

--- a/debsources/tests/test_web_patches.py
+++ b/debsources/tests/test_web_patches.py
@@ -70,6 +70,23 @@ class CopyrightTestCase(DebsourcesBaseWebTests, unittest.TestCase):
                           follow_redirects=True)
         self.assertIn("Package: gnubg / 1.02.000-2", rv.data)
 
+    def test_package_summary(self):
+        rv = self.app.get('/patches/summary/beignet/1.0.0-1/')
+        self.assertIn("Enhance debug output", rv.data)
+        self.assertIn("utests/builtin_acos_asin.cpp  |    8 +++++---", rv.data)
+
+        # test non quilt package
+        rv = self.app.get('/patches/summary/cvsnt/2.5.03.2382-3/')
+        self.assertIn("The format of the patches in the package", rv.data)
+
+    def test_view_patch(self):
+        rv = self.app.get('/patches/patch/beignet/1.0.0-1/'
+                          'Enable-test-debug.patch/')
+        self.assertIn('<code id="sourcecode" class="diff">', rv.data)
+        # highlight inside?
+        self.assertIn('hljs.highlightBlock', rv.data)
+        self.assertIn('highlight/highlight.min.js"></script>', rv.data)
+
 
 if __name__ == '__main__':
     unittest.main(exit=False)


### PR DESCRIPTION
This patch implements the summary view of a package and the patch view with highlighted syntax.
First 4 commits are from PR#32 so they shouldn't be taken into account in this PR.

urls to check:
- /patches/patch/beignet/1.0.0-1/Enable-test-debug.patch/
- /patches/summary/beignet/1.0.0-1/ 

The summary is not yet completed since i can't insert the checksum of the orig.tar.gz (I might delete it if you consider merging this). 

Added some tests as well. 

P.S I think it is better to push patch tracker commits in a separate branch since there are a lot of commits from the copyright tracker not pushed yet and we might have some complications to solve which might be better to solve only once when merging the patch-tracker branch in master. 
