### PR TITLE
File deltas links to Debsources and several bug fixes

### DIFF
--- a/debsources/app/copyright/templates/copyright/checksum.html
+++ b/debsources/app/copyright/templates/copyright/checksum.html
@@ -10,7 +10,7 @@
 
 {% block title %}Checksum: {{ checksum }}{% endblock %}
 
-{% block breadcrumbs %}checksum / {{ checksum }}{% endblock %}
+{% block breadcrumbs %} <a href='{{ url_for(".index") }}'>Copyright</a> / Checksum / {{ checksum }}{% endblock %}
 
 {% block content %}
 <h2>{{ self.title() }}</h2>

--- a/debsources/app/copyright/templates/copyright/file.html
+++ b/debsources/app/copyright/templates/copyright/file.html
@@ -10,7 +10,7 @@
 
 {% block title %}Filename: {{ path }}{% endblock %}
 
-{% block breadcrumbs %}file name / {{ path }}{% endblock %}
+{% block breadcrumbs %}<a href='{{ url_for(".index") }}'>Copyright</a> / File name / {{ path }}{% endblock %}
 
 {% block content %}
 {% import "copyright/macros.html" as macro %}

--- a/debsources/app/copyright/templates/copyright/license.html
+++ b/debsources/app/copyright/templates/copyright/license.html
@@ -17,7 +17,7 @@
   <script src="{{ config.JQUERY_JS_FOLDER }}/jquery.min.js"></script>
   <script src="{{ url_for('.static', filename='javascript/license.js') }}"></script> 
 {% endblock %}
-{% block breadcrumbs %} Copyright / <a href="{{ url_for('.versions', packagename=package) }}">{{ package }}</a> 
+{% block breadcrumbs %} <a href='{{ url_for(".index") }}'>Copyright</a> / <a href="{{ url_for('.versions', packagename=package) }}">{{ package }}</a> 
             /{{ version }}
 {% endblock %}
 {% block title %}Package: {{ package }}{% endblock %}

--- a/debsources/app/copyright/views.py
+++ b/debsources/app/copyright/views.py
@@ -34,6 +34,10 @@ class LicenseView(GeneralView):
 
         package = path_dict[0]
         version = path_dict[1]
+
+        if len(path_dict) > 2:
+            raise Http404ErrorSuggestions(package, version, '')
+
         path = '/'.join(path_dict[2:])
 
         if version == "latest":  # we search the latest available version

--- a/debsources/app/patches/templates/patches/patch.html
+++ b/debsources/app/patches/templates/patches/patch.html
@@ -15,7 +15,7 @@
         href="{{ config.HIGHLIGHT_JS_FOLDER }}/styles/{{ config.HIGHLIGHT_STYLE }}.css">
   <script src="{{ config.HIGHLIGHT_JS_FOLDER }}/highlight.min.js"></script> 
 {% endblock %}
-{% block breadcrumbs %} Patch / <a href="{{ url_for('.versions', packagename=package) }}">{{ package }}</a> / <a href="{{ url_for('.summary', path_to=path) }}">{{ version }}</a>
+{% block breadcrumbs %} <a href='{{ url_for(".index") }}'>Patches</a> / Patch / <a href="{{ url_for('.versions', packagename=package) }}">{{ package }}</a> / <a href="{{ url_for('.summary', path_to=path) }}">{{ version }}</a>
 {% endblock %}
 {% block title %}Package: {{ package }}{% endblock %}
 {% block content %}

--- a/debsources/app/patches/templates/patches/summary.html
+++ b/debsources/app/patches/templates/patches/summary.html
@@ -48,7 +48,9 @@
         {% for patch in series %}
         <tr>
           <td>{{ patch.replace('.patch', '').replace('-', ' ') }}</td>
-          <td><pre>{{ patches_info[patch]['summary']}}</pre></td>
+          <td><p>{%- for line in patches_info[patch]['deltas'] %}
+            <a href="{{ url_for('sources.source', path_to=path + '/' + line['filepath'])}}">{{ line['filepath'] }}</a> | {{ line['deltas'] }}<br />
+          {%- endfor %} {{ patches_info[patch]['summary'] }}</p></td>
           <td><a href="{{ url_for('.patch', path_to=path + '/' +patch.rstrip())}}">View</a></td>
           <td><a href="{{ patches_info[patch]['download'] }}">download</a></td>
         </tr>

--- a/debsources/app/patches/templates/patches/summary.html
+++ b/debsources/app/patches/templates/patches/summary.html
@@ -30,7 +30,7 @@
   </tr>
 </table>
 
-{% if format.rstrip() != '3.0 (quilt)' %}
+{% if supported != true %}
   <p>The format of the patches in the package is not yet supported! </p>
 {% else %}
   {% if patches == 0 %}

--- a/debsources/app/patches/templates/patches/summary.html
+++ b/debsources/app/patches/templates/patches/summary.html
@@ -10,8 +10,7 @@
 {% block head %}
 {{ super() }} 
 {% endblock %}
-{% block breadcrumbs %} Patches / <a href="{{ url_for('.versions', packagename=package) }}">{{ package }}</a> 
-            /{{ version }}
+{% block breadcrumbs %} <a href='{{ url_for(".index") }}'>Patches</a> / <a href="{{ url_for('.versions', packagename=package) }}">{{ package }}</a> /{{ version }}
 {% endblock %}
 {% block title %}Package: {{ package }}{% endblock %}
 {% block content %}

--- a/debsources/app/patches/templates/patches/summary.html
+++ b/debsources/app/patches/templates/patches/summary.html
@@ -26,7 +26,7 @@
   <tr>
     <td>{{ package }}</td>
     <td>{{ version }}</td>
-    <td>{{ format }}</td>
+    <td>{{ format.rstrip() }}</td>
   </tr>
 </table>
 

--- a/debsources/app/patches/views.py
+++ b/debsources/app/patches/views.py
@@ -160,7 +160,7 @@ class PatchView(GeneralView):
         path_dict = path_to.split('/')
         package = path_dict[0]
         version = path_dict[1]
-        patch = '/'.join(path_dict[2])
+        patch = '/'.join(path_dict[2:])
         try:
             serie_path, loc = get_sources_path(session, package, version,
                                                current_app.config,

--- a/debsources/app/patches/views.py
+++ b/debsources/app/patches/views.py
@@ -155,8 +155,6 @@ class PatchView(GeneralView):
         version = path_dict[1]
         patch = path_dict[2]
 
-        path = '/'.join(path_dict[0:-1])
-
         try:
             serie_path, loc = get_sources_path(session, package, version,
                                                current_app.config,
@@ -169,7 +167,7 @@ class PatchView(GeneralView):
 
         return dict(package=package,
                     version=version,
-                    path=path,
+                    path=path_to,
                     nlines=sourcefile.get_number_of_lines(),
-                    file_language=sourcefile.get_file_language(),
+                    file_language='diff',
                     code=sourcefile)

--- a/debsources/app/patches/views.py
+++ b/debsources/app/patches/views.py
@@ -98,7 +98,8 @@ class SummaryView(GeneralView):
                         path=path_to,
                         format='unknown')
 
-        format_file = open(source_format).read()
+        with io.open(source_format, mode='r', encoding='utf-8') as f:
+            format_file = f.read()
         if format_file.rstrip() not in ACCEPTED_FORMATS:
             return dict(package=package,
                         version=version,

--- a/debsources/app/sources/templates/sources/source_base.html
+++ b/debsources/app/sources/templates/sources/source_base.html
@@ -8,7 +8,7 @@
 
 {% extends "sources/base.html" %}
 
-{% block breadcrumbs %}source / {% for (p, link) in pathl[:-1]
+{% block breadcrumbs %}<a href="{{ url_for('.index') }}">{{ request.blueprint }}</a> / {% for (p, link) in pathl[:-1]
     %}<a href="{{ link }}">{{ p }}</a> / {%
   endfor %}{{ pathl[-1][0] }}{% endblock %}
 

--- a/debsources/app/templates/list.html
+++ b/debsources/app/templates/list.html
@@ -10,7 +10,7 @@
 
 {% block title %}Package list: page {{ page }}{% endblock %}
 
-{% block breadcrumbs %}packages list / {{ page }}{% endblock %}
+{% block breadcrumbs %}<a href="{{ url_for('.index') }}">{{ request.blueprint }}</a> / packages list / {{ page }}{% endblock %}
 
 {% block content %}
 

--- a/debsources/app/templates/prefix.html
+++ b/debsources/app/templates/prefix.html
@@ -9,7 +9,7 @@
 
 {% block title %}Package list: prefix {{ prefix }}{% endblock %}
 
-{% block breadcrumbs %}packages by prefix / {{ prefix }}{% endblock %}
+{% block breadcrumbs %}<a href="{{ url_for('.index') }}">{{ request.blueprint }}</a> / packages by prefix / {{ prefix }}{% endblock %}
 
 {% block content %}
 

--- a/debsources/tests/test_web_cp.py
+++ b/debsources/tests/test_web_cp.py
@@ -323,6 +323,13 @@ class CopyrightTestCase(DebsourcesBaseWebTests, unittest.TestCase):
                    "rce.org/licenses/GPL-3.0\">GPL-3+</a>"
         self.assertIn(synopsis, rv.data)
 
+    def test_license_404(self):
+        rv = self.app.get("/copyright/license/gnubg/1.02.000-2/foo",
+                          follow_redirects=True)
+        self.assertIn('other versions of this package are available', rv.data)
+        link = '<a href="/copyright/license/gnubg/0.90+20091206-4/">'
+        self.assertIn(link, rv.data)
+
 
 if __name__ == '__main__':
     unittest.main(exit=False)

--- a/debsources/tests/test_web_patches.py
+++ b/debsources/tests/test_web_patches.py
@@ -93,6 +93,19 @@ class CopyrightTestCase(DebsourcesBaseWebTests, unittest.TestCase):
         self.assertIn('<a href="/src/beignet/1.0.0-1/src/cl_utils.h/">',
                       rv.data)
 
+    def test_summary_404(self):
+        rv = self.app.get("/patches/summary/gnubg/1.02.000-2/foo",
+                          follow_redirects=True)
+        self.assertIn('other versions of this package are available', rv.data)
+        link = '<a href="/patches/summary/gnubg/0.90+20091206-4/">'
+        self.assertIn(link, rv.data)
+
+    def test_3_native_format(self):
+        rv = self.app.get("/patches/summary/nvidia-support/20131102+1/")
+        self.assertIn('<td>3.0 (native)</td>', rv.data)
+        self.assertIn('<p>This package has no patches.</p>', rv.data)
+        self.assertNotIn('The format of the patches in the package', rv.data)
+
 
 if __name__ == '__main__':
     unittest.main(exit=False)

--- a/debsources/tests/test_web_patches.py
+++ b/debsources/tests/test_web_patches.py
@@ -73,7 +73,8 @@ class CopyrightTestCase(DebsourcesBaseWebTests, unittest.TestCase):
     def test_package_summary(self):
         rv = self.app.get('/patches/summary/beignet/1.0.0-1/')
         self.assertIn("Enhance debug output", rv.data)
-        self.assertIn("utests/builtin_acos_asin.cpp  |    8 +++++---", rv.data)
+        self.assertIn("utests/builtin_acos_asin.cpp</a> |    8 +++++---",
+                      rv.data)
 
         # test non quilt package
         rv = self.app.get('/patches/summary/cvsnt/2.5.03.2382-3/')
@@ -86,6 +87,11 @@ class CopyrightTestCase(DebsourcesBaseWebTests, unittest.TestCase):
         # highlight inside?
         self.assertIn('hljs.highlightBlock', rv.data)
         self.assertIn('highlight/highlight.min.js"></script>', rv.data)
+
+    def test_file_deltas_links(self):
+        rv = self.app.get('/patches/summary/beignet/1.0.0-1/')
+        self.assertIn('<a href="/src/beignet/1.0.0-1/src/cl_utils.h/">',
+                      rv.data)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR has several bugs fixes (those discussed at irc and some more i found):
- raise 404 when at summary/package/version/foo or license/package/version/foo (added some tests as well)
- enforce diff highlight when viewing a patch in the patch tracker
- added index links in the breadcrumbs for the copyright and patch BP
- Added support for 3.0 native packages
- Allowed patches to be in subdir of debian/patches ( http://sourcesdev.debian.net/patches/summary/azureus/4.3.0.6-5/ ). we don't have a similar situation in the test data so i  couldn't add a test

and finally created links to Debsources from the file-deltas.
Let me know if you prefer to have the bug fixes in another PR. 
