### PR TITLE
Patch description and BTS link

### DIFF
--- a/debsources/app/copyright/templates/copyright/file.html
+++ b/debsources/app/copyright/templates/copyright/file.html
@@ -10,7 +10,7 @@
 
 {% block title %}Filename: {{ path }}{% endblock %}
 
-{% block breadcrumbs %}<a href='{{ url_for(".index") }}'>Copyright</a> / File name / {{ path }}{% endblock %}
+{% block breadcrumbs %}<a href='{{ url_for(".index") }}'>Copyright</a> / <a href="{{ url_for('.versions', packagename=package )}}"> {{ package }}</a> / <a href="{{ url_for('.license', path_to=package + '/' + version)}}">{{ version }}</a> / {{ path.replace('/', ' / ') }}{% endblock %}
 
 {% block content %}
 {% import "copyright/macros.html" as macro %}

--- a/debsources/app/patches/templates/patches/patch.html
+++ b/debsources/app/patches/templates/patches/patch.html
@@ -15,7 +15,7 @@
         href="{{ config.HIGHLIGHT_JS_FOLDER }}/styles/{{ config.HIGHLIGHT_STYLE }}.css">
   <script src="{{ config.HIGHLIGHT_JS_FOLDER }}/highlight.min.js"></script> 
 {% endblock %}
-{% block breadcrumbs %} <a href='{{ url_for(".index") }}'>Patches</a> / Patch / <a href="{{ url_for('.versions', packagename=package) }}">{{ package }}</a> / <a href="{{ url_for('.summary', path_to=path) }}">{{ version }}</a>
+{% block breadcrumbs %} <a href='{{ url_for(".index") }}'>Patches</a> / Patch / <a href="{{ url_for('.versions', packagename=package) }}">{{ package }}</a> / <a href="{{ url_for('.summary', path_to=package + '/' + version) }}">{{ version }}</a>
 {% endblock %}
 {% block title %}Package: {{ package }}{% endblock %}
 {% block content %}

--- a/debsources/app/patches/templates/patches/summary.html
+++ b/debsources/app/patches/templates/patches/summary.html
@@ -41,6 +41,7 @@
        <tr class="head">
           <th>Patch</th>
           <th>File delta</th>
+          <th>Description</th>
           <th>View</th>
           <th>Download</th>
         </tr>
@@ -50,6 +51,7 @@
           <td><p>{%- for line in patches_info[patch]['deltas'] %}
             <a href="{{ url_for('sources.source', path_to=path + '/' + line['filepath'])}}">{{ line['filepath'] }}</a> | {{ line['deltas'] }}<br />
           {%- endfor %} {{ patches_info[patch]['summary'] }}</p></td>
+          <td><pre>{{ patches_info[patch]['description'] }}</pre></td>
           <td><a href="{{ url_for('.patch', path_to=path + '/' +patch.rstrip())}}">View</a></td>
           <td><a href="{{ patches_info[patch]['download'] }}">download</a></td>
         </tr>

--- a/debsources/app/patches/templates/patches/summary.html
+++ b/debsources/app/patches/templates/patches/summary.html
@@ -56,7 +56,7 @@
           <p>Bug: <a href="https://bugs.debian.org/{{patches_info[patch]['bug']}}">#{{patches_info[patch]['bug']}}</a></p>   
           {%- endif %}
           </td>
-          <td><a href="{{ url_for('.patch', path_to=path + '/' +patch.rstrip())}}">View</a></td>
+          <td><a href="{{ url_for('.patch', path_to=path + '/' +patch.rstrip().split(' ')[0])}}">View</a></td>
           <td><a href="{{ patches_info[patch]['download'] }}">download</a></td>
         </tr>
         {% endfor %}

--- a/debsources/app/patches/templates/patches/summary.html
+++ b/debsources/app/patches/templates/patches/summary.html
@@ -51,7 +51,11 @@
           <td><p>{%- for line in patches_info[patch]['deltas'] %}
             <a href="{{ url_for('sources.source', path_to=path + '/' + line['filepath'])}}">{{ line['filepath'] }}</a> | {{ line['deltas'] }}<br />
           {%- endfor %} {{ patches_info[patch]['summary'] }}</p></td>
-          <td><pre>{{ patches_info[patch]['description'] }}</pre></td>
+          <td><pre>{{ patches_info[patch]['description'] }}</pre>
+          {%- if patches_info[patch]['bug'] != "" %}
+          <p>Bug: <a href="https://bugs.debian.org/{{patches_info[patch]['bug']}}">#{{patches_info[patch]['bug']}}</a></p>   
+          {%- endif %}
+          </td>
           <td><a href="{{ url_for('.patch', path_to=path + '/' +patch.rstrip())}}">View</a></td>
           <td><a href="{{ patches_info[patch]['download'] }}">download</a></td>
         </tr>

--- a/debsources/app/patches/views.py
+++ b/debsources/app/patches/views.py
@@ -87,12 +87,13 @@ class SummaryView(GeneralView):
         patches_info = dict()
         for serie in series:
             if not serie.startswith('#'):
+                patch = serie.rstrip().split(' ')[0]
                 try:
                     serie_path, loc = get_sources_path(session, package,
                                                        version,
                                                        current_app.config,
                                                        'debian/patches/'
-                                                       + serie.rstrip())
+                                                       + patch)
                     p = subprocess.Popen(["diffstat", "-p1", serie_path],
                                          stdout=subprocess.PIPE)
                     summary, err = p.communicate()

--- a/debsources/app/patches/views.py
+++ b/debsources/app/patches/views.py
@@ -217,7 +217,6 @@ class PatchView(GeneralView):
 
         return dict(package=package,
                     version=version,
-                    path=path_to,
                     nlines=sourcefile.get_number_of_lines(),
                     file_language='diff',
                     code=sourcefile)

--- a/debsources/app/patches/views.py
+++ b/debsources/app/patches/views.py
@@ -42,40 +42,41 @@ class SummaryView(GeneralView):
         deltas_summary = '\n' + summary.splitlines()[-1]
         return file_deltas, deltas_summary
 
-    def _get_patch_description(self, path):
-        """ Parse a patch to extract the description if it exists
+    def _get_patch_details(self, path):
+        """ Parse a patch to extract the description and or bug if it exists
         """
         with open(path, 'r') as content_file:
             patch = content_file.read()
         # check if subject exists
         keywords = ['description:', 'subject:']
         if not any(key in patch.lower() for key in keywords):
-            return '---'
+            return ('---', '')
         else:
             # split by --- or +++ (file deltas) and then parse as a tag/value
-            # document to extract Description or subject if any
+            # document to extract description or subject or bug
             contents = re.split(r'---|\+\+\+', patch)[0]
-            dsc = ""
+            dsc = "---"
+            bug = ""
             in_description = False
             # possible fields besides description and subject
             # used to extract multiline descriptions
-            fields = ['origin:', 'bug:', 'forwarded:', 'author:', 'from:',
-                      'reviewed-by:', 'acked-by', 'last-update',
-                      'applied-upstream']
+            fields = ['origin:', 'forwarded:', 'author:', 'from:',
+                      'reviewed-by:', 'acked-by:', 'last-update:',
+                      'applied-upstream:', 'index:', 'diff']
             for line in contents.split('\n'):
                 if 'description:' in line.lower() or \
                    'subject:' in line.lower():
                     dsc = re.split(r'description:|subject:', line.lower())[1] \
                         + '\n'
                     in_description = True
+                elif 'bug: #' in line.lower():
+                    bug = line.lower().split('bug: #')[1]
+                    in_description = False
                 elif any(key in line.lower() for key in fields):
                     in_description = False
                 elif in_description:
                     dsc += line + '\n'
-            if dsc != "":
-                return dsc
-            else:
-                return '---'
+            return (dsc, bug)
 
     def parse_patch_series(self, session, package, version, config, series):
         """ Parse a list of patches available in `series` and create a dict
@@ -97,11 +98,12 @@ class SummaryView(GeneralView):
                 file_deltas, deltas_summary = self._parse_file_deltas(summary,
                                                                       package,
                                                                       version)
-                description = self._get_patch_description(serie_path)
+                description, bug = self._get_patch_details(serie_path)
                 patches_info[serie] = dict(deltas=file_deltas,
                                            summary=deltas_summary,
                                            download=loc.get_raw_url(),
-                                           description=description)
+                                           description=description,
+                                           bug=bug)
             except (FileOrFolderNotFound, InvalidPackageOrVersionError):
                 patches_info[serie] = dict(summary='Patch does not exist')
         return patches_info

--- a/debsources/tests/test_web_patches.py
+++ b/debsources/tests/test_web_patches.py
@@ -106,6 +106,28 @@ class CopyrightTestCase(DebsourcesBaseWebTests, unittest.TestCase):
         self.assertIn('<p>This package has no patches.</p>', rv.data)
         self.assertNotIn('The format of the patches in the package', rv.data)
 
+    def test_bts_link(self):
+        rv = self.app.get('/patches/summary/ledit/2.03-2/')
+        self.assertIn('<a href="https://bugs.debian.org/672479">#672479</a>',
+                      rv.data)
+        # test no bug
+        rv = self.app.get('/patches/patch/gnubg/1.02.000-2/')
+        self.assertNotIn('Bug: ', rv.data)
+
+    def test_extract_description(self):
+        rv = self.app.get('/patches/summary/gnubg/1.02.000-2/')
+        self.assertIn('collected debian patches for gnubg', rv.data)
+        # test long dsc
+        rv = self.app.get('/patches/summary/beignet/1.0.0-1/')
+        long_dsc = 'Turn on udebug so tests print their full output, and mark' \
+                   ' failures\nby &#34;failed:&#34; instead of invisible-in-' \
+                   'logs colour.'
+        self.assertIn(long_dsc, rv.data)
+        # test no description header
+        rv = self.app.get('/patches/summary/unrar-nonfree/1:5.0.10-1/')
+        self.assertIn('fix buildflags', rv.data)
+        self.assertIn('---', rv.data)
+
 
 if __name__ == '__main__':
     unittest.main(exit=False)


### PR DESCRIPTION
Retrieve description and or bug if they exist in the patch headers.

You can test these routes:
- /patches/summary/gnubg/1.02.000-2/
- /patches/summary/beignet/1.0.0-1/
- /patches/summary/ledit/2.03-2/ (with bts link)

I was reluctant to add a column only for BTS since i wasn't sure if most patches fix a bug or not.
