### PR TITLE
Be more explicit when d/copyright file missing in LicenseView

### DIFF
--- a/debsources/app/copyright/templates/copyright/404_missing.html
+++ b/debsources/app/copyright/templates/copyright/404_missing.html
@@ -1,0 +1,25 @@
+{#
+  Copyright (C) 2015  The Debsources developers <info@sources.debian.net>.
+  See the AUTHORS file at the top-level directory of this distribution and at
+  https://anonscm.debian.org/gitweb/?p=qa/debsources.git;a=blob;f=AUTHORS;hb=HEAD
+  License: GNU Affero General Public License, version 3 or above.
+#}
+{% extends name+"/base.html" %}
+
+{% block title %}404{% endblock %}
+{% block content %}
+<h2>{{ self.title() }}</h2>
+<p>The specific version of the package you requested does not have,
+a debian/copyright file, but other versions of this package are available in
+the database.
+The license you are looking for might exist in one of the following
+versions:
+<ul>
+{% for s in suggestions %}
+  <li><a href="{{ url_for('.license', path_to=s) }}">{{ s }}</a></li>
+{% endfor %}
+</ul>
+</p> 
+<a href="/">Go home</a>
+
+{% endblock %}

--- a/debsources/app/copyright/views.py
+++ b/debsources/app/copyright/views.py
@@ -18,7 +18,8 @@ from debian.debian_support import version_compare
 
 import debsources.query as qry
 from debsources.excepts import (Http404ErrorSuggestions, FileOrFolderNotFound,
-                                InvalidPackageOrVersionError)
+                                InvalidPackageOrVersionError,
+                                Http404MissingCopyright)
 
 from ..views import GeneralView, ChecksumView, session
 from ..sourcecode import SourceCodeIterator
@@ -58,8 +59,7 @@ class LicenseView(GeneralView):
                                                    current_app.config)
         except (FileOrFolderNotFound, InvalidPackageOrVersionError) as e:
             if isinstance(e, FileOrFolderNotFound):
-                raise Http404ErrorSuggestions(package, version,
-                                              'debian/copyright')
+                raise Http404MissingCopyright(package, version, '')
             else:
                 raise Http404ErrorSuggestions(package, version, '')
 

--- a/debsources/excepts.py
+++ b/debsources/excepts.py
@@ -36,5 +36,13 @@ class Http404ErrorSuggestions(Http404Error):
         super(Http404ErrorSuggestions, self).__init__()
 
 
+class Http404MissingCopyright(Http404Error):
+    def __init__(self, package, version, path):
+        self.package = package
+        self.version = version
+        self.path = path
+        super(Http404MissingCopyright, self).__init__()
+
+
 class Http403Error(Exception):
     pass


### PR DESCRIPTION
This fixes the issue with missing d/copyright files.
Reference: http://sourcesdev.debian.net/copyright/license/libc/5.4.38-1.1/
