### PR TITLE
Enhancement versions view

### DIFF
--- a/debsources/app/copyright/license_helper.py
+++ b/debsources/app/copyright/license_helper.py
@@ -54,7 +54,7 @@ def parse_license(sources_path):
 
 
 def license_url(package, version):
-    return url_for('.license', path_to=(package + '/' + version))
+    return url_for('.license', packagename=package, version=version)
 
 
 def get_license(session, package, version, path):

--- a/debsources/app/copyright/routes.py
+++ b/debsources/app/copyright/routes.py
@@ -106,7 +106,7 @@ bp_copyright.add_url_rule(
 
 # LICENSEVIEW
 bp_copyright.add_url_rule(
-    '/license/<path:path_to>/',
+    '/license/<string:packagename>/<string:version>/',
     view_func=LicenseView.as_view(
         'license',
         render_func=bind_render('copyright/license.html'),

--- a/debsources/app/copyright/templates/copyright/404_suggestions.html
+++ b/debsources/app/copyright/templates/copyright/404_suggestions.html
@@ -11,7 +11,7 @@ The license you are looking for might exist in one of the following
 versions:
 <ul>
 {% for s in suggestions %}
-  <li><a href="{{ url_for('.license', path_to=s) }}">{{ s }}</a></li>
+  <li><a href="{{ url_for('.license', packagename=s.split('/')[0], version=s.split('/')[1]) }}">{{ s }}</a></li>
 {% endfor %}
 </ul>
 </p>

--- a/debsources/app/copyright/templates/copyright/file.html
+++ b/debsources/app/copyright/templates/copyright/file.html
@@ -10,7 +10,7 @@
 
 {% block title %}Filename: {{ path }}{% endblock %}
 
-{% block breadcrumbs %}<a href='{{ url_for(".index") }}'>Copyright</a> / <a href="{{ url_for('.versions', packagename=package )}}"> {{ package }}</a> / <a href="{{ url_for('.license', path_to=package + '/' + version)}}">{{ version }}</a> / {{ path.replace('/', ' / ') }}{% endblock %}
+{% block breadcrumbs %}<a href='{{ url_for(".index") }}'>Copyright</a> / <a href="{{ url_for('.versions', packagename=package )}}"> {{ package }}</a> / <a href="{{ url_for('.license', packagename=package, version=version)}}">{{ version }}</a> / {{ path.replace('/', ' / ') }}{% endblock %}
 
 {% block content %}
 {% import "copyright/macros.html" as macro %}

--- a/debsources/app/copyright/templates/copyright/macros.html
+++ b/debsources/app/copyright/templates/copyright/macros.html
@@ -15,8 +15,8 @@
 
 {%- macro view_license(c) -%}
     {%- if c['license'] is not none %}
-      <p>According to the <a href="{{url_for('.license', path_to=(c['package']+'/'+c['version']))}}">d/copyright</a> file, <b>{{c['path']}}</b> in the package <b>{{c['package']}}</b>, version <b>{{c['version']}}</b> is licensed under <b>{{c['license']}}</b></p>
+      <p>According to the <a href="{{url_for('.license', packagename=c['package'], version=c['version'])}}">d/copyright</a> file, <b>{{c['path']}}</b> in the package <b>{{c['package']}}</b>, version <b>{{c['version']}}</b> is licensed under <b>{{c['license']}}</b></p>
     {%- else %}
-        <p>The <a href="{{url_for('.license', path_to=(c['package']+'/'+c['version']))}}">d/copyright</a> file for the file <b>{{c['path']}}</b> in the package <b>{{c['package']}}</b>, version <b>{{c['version']}}</b> is not machine readable</p>
+        <p>The <a href="{{url_for('.license', packagename=c['package'], version=c['version'])}}">d/copyright</a> file for the file <b>{{c['path']}}</b> in the package <b>{{c['package']}}</b>, version <b>{{c['version']}}</b> is not machine readable</p>
     {%- endif %}
 {%- endmacro %}

--- a/debsources/app/copyright/templates/copyright/package.html
+++ b/debsources/app/copyright/templates/copyright/package.html
@@ -5,7 +5,7 @@
   License: GNU Affero General Public License, version 3 or above.
 #}
 {# copied from templates/source_base.html #}
-{% extends "sources/source_base.html" %}
+{% extends name+"/source_base.html" %}
 
 {% block head %}
 {{ super() }}
@@ -13,11 +13,23 @@
       href="{{ url_for('sources.static', filename='css/source_folder.css') }}" />
 {% endblock %}
 
+{% block breadcrumbs %}<a href="{{ url_for('.index') }}">{{ request.blueprint }}</a> /{% endblock %}
+
 {% block title %}Package: {{ package }}{% endblock %}
 {% block source_content %}
 <h2>{{ self.title() }}</h2>
 {{ macros.show_suite(suite) }}
 
-{{ macros.show_versions(versions, path, '.license', config['ICONS_FOLDER'])}}
+<ul id="ls">
+  {% for v in versions %}
+  <li><a href="{{ url_for('.license', packagename=package, version=v.version) }}">
+      {{ v.version }}</a>
+    ({{ v.area }})
+    {% if v.suites %}
+        [{{ ", ".join(v.suites) }}]
+    {% endif %}
 
+  </li>
+  {% endfor %}
+  </ul>
 {% endblock %}

--- a/debsources/app/copyright/views.py
+++ b/debsources/app/copyright/views.py
@@ -30,56 +30,45 @@ from . import license_helper as helper
 
 class LicenseView(GeneralView):
 
-    def get_objects(self, path_to):
-        path_dict = path_to.split('/')
-
-        package = path_dict[0]
-        version = path_dict[1]
-
-        if len(path_dict) > 2:
-            raise Http404ErrorSuggestions(package, version, '')
-
-        path = '/'.join(path_dict[2:])
-
+    def get_objects(self, packagename, version):
         if version == "latest":  # we search the latest available version
             return self._handle_latest_version(request.endpoint,
-                                               package, path)
+                                               packagename, "")
 
-        versions = self.handle_versions(version, package, path)
+        versions = self.handle_versions(version, packagename, "")
         if versions:
-            redirect_url_parts = [package, versions[-1]]
-            if path:
-                redirect_url_parts.append(path)
+            redirect_url_parts = [packagename, versions[-1]]
             redirect_url = '/'.join(redirect_url_parts)
             return self._redirect_to_url(request.endpoint,
                                          redirect_url, redirect_code=302)
 
         try:
-            sources_path = helper.get_sources_path(session, package, version,
+            sources_path = helper.get_sources_path(session, packagename,
+                                                   version,
                                                    current_app.config)
         except (FileOrFolderNotFound, InvalidPackageOrVersionError) as e:
             if isinstance(e, FileOrFolderNotFound):
-                raise Http404MissingCopyright(package, version, '')
+                raise Http404MissingCopyright(packagename, version, '')
             else:
-                raise Http404ErrorSuggestions(package, version, '')
+                raise Http404ErrorSuggestions(packagename, version, '')
 
         try:
             c = helper.parse_license(sources_path)
         except Exception:
             # non machine readable license
             sourcefile = SourceCodeIterator(sources_path)
-            return dict(package=package,
+            return dict(package=packagename,
                         version=version,
                         code=sourcefile,
                         dump='True',
                         nlines=sourcefile.get_number_of_lines(),)
         renderer = RenderLicense(c, 'jinja')
-        return dict(package=package,
+        return dict(package=packagename,
                     version=version,
                     dump='False',
                     header=renderer.render_header(),
                     files=renderer.render_files(
-                        "/src/" + package + "/" + version + "/"),
+                        "/src/" + packagename + "/" + version + "/"),
                     licenses=renderer.render_licenses())
 
 

--- a/debsources/app/infobox.py
+++ b/debsources/app/infobox.py
@@ -119,7 +119,7 @@ class Infobox(object):
 
         """
         return url_for('copyright.license',
-                       path_to=self.package + '/' + self.version)
+                       packagename=self.package, version=self.version)
 
     def get_infos(self):
         """

--- a/debsources/app/patches/patches_helper.py
+++ b/debsources/app/patches/patches_helper.py
@@ -98,8 +98,8 @@ def get_patch_format(session, package, version, config):
         source_format, loc = get_sources_path(session, package, version,
                                               config,
                                               'debian/source/format')
-    except (FileOrFolderNotFound, InvalidPackageOrVersionError):
-        raise FileOrFolderNotFound
+    except (FileOrFolderNotFound, InvalidPackageOrVersionError) as e:
+        raise e
     with io.open(source_format, mode='r', encoding='utf-8') as f:
         format_file = f.read()
     return format_file

--- a/debsources/app/patches/patches_helper.py
+++ b/debsources/app/patches/patches_helper.py
@@ -10,8 +10,16 @@
 # https://anonscm.debian.org/gitweb/?p=qa/debsources.git;a=blob;f=COPYING;hb=HEAD
 from __future__ import absolute_import
 import re
+import io
 import logging
 import subprocess
+
+from debsources.navigation import Location, SourceFile
+from debsources.excepts import (FileOrFolderNotFound,
+                                InvalidPackageOrVersionError)
+
+ACCEPTED_FORMATS = ['3.0 (quilt)',
+                    '3.0 (native)']
 
 
 def get_patch_details(path):
@@ -61,3 +69,60 @@ def get_file_deltas(serie_path):
         logging.warn('Reading file deltas patch: %s, error: %s', serie_path,
                      err)
     return summary
+
+
+def get_sources_path(session, package, version, config, path):
+    ''' Creates a sources_path. Returns exception when it arises
+    '''
+    try:
+        location = Location(session,
+                            config["SOURCES_DIR"],
+                            config["SOURCES_STATIC"],
+                            package, version, path)
+    except (FileOrFolderNotFound, InvalidPackageOrVersionError) as e:
+        raise e
+
+    file_ = SourceFile(location)
+
+    sources_path = file_.get_raw_url().replace(
+        config['SOURCES_STATIC'],
+        config['SOURCES_DIR'],
+        1)
+    return sources_path, file_
+
+
+def get_patch_format(session, package, version, config):
+    """ Retrieves a patch format from /debian/source/format
+    """
+    try:
+        source_format, loc = get_sources_path(session, package, version,
+                                              config,
+                                              'debian/source/format')
+    except (FileOrFolderNotFound, InvalidPackageOrVersionError):
+        raise FileOrFolderNotFound
+    with io.open(source_format, mode='r', encoding='utf-8') as f:
+        format_file = f.read()
+    return format_file
+
+
+def is_supported(_format):
+    """ Determines whether a `_format` is supported
+    """
+    if _format not in ACCEPTED_FORMATS:
+        return False
+    else:
+        return True
+
+
+def get_patch_series(session, package, version, config):
+    """ Retrieves the patch series from debian/patches/series
+    """
+    try:
+        series, loc = get_sources_path(session, package, version,
+                                       config,
+                                       'debian/patches/series')
+    except (FileOrFolderNotFound, InvalidPackageOrVersionError):
+        raise FileOrFolderNotFound
+    with io.open(series, mode='r', encoding='utf-8') as f:
+            series = f.readlines()
+    return series

--- a/debsources/app/patches/routes.py
+++ b/debsources/app/patches/routes.py
@@ -18,9 +18,8 @@ from . import bp_patches
 
 from ..helper import bind_render
 from ..views import (IndexView, Ping, PrefixView, ErrorHandler,
-                     ListPackagesView, PackageVersionsView, SearchView,
-                     DocView, AboutView)
-from .views import SummaryView, PatchView
+                     ListPackagesView, SearchView, DocView, AboutView)
+from .views import SummaryView, PatchView, VersionsView
 
 
 # context vars
@@ -91,7 +90,7 @@ bp_patches.add_url_rule(
 # VERSIONSVIEW
 bp_patches.add_url_rule(
     '/summary/<string:packagename>/',
-    view_func=PackageVersionsView.as_view(
+    view_func=VersionsView.as_view(
         'versions',
         render_func=bind_render('patches/package.html'),
         err_func=ErrorHandler('patches')))
@@ -99,18 +98,14 @@ bp_patches.add_url_rule(
 # api
 bp_patches.add_url_rule(
     '/api/summary/<string:packagename>/',
-    view_func=PackageVersionsView.as_view(
+    view_func=VersionsView.as_view(
         'api_patch_versions',
         render_func=jsonify,
         err_func=ErrorHandler(mode='json')))
 
 # SUMMARYVIEW
-# Why not summary/<string:packagename>/<string:version>
-# Because then the patches blueprint must have its own show versions in the
-# macros since the other two blueprints will have a path_to parameter instead
-# of a packagename and version parameters.
 bp_patches.add_url_rule(
-    '/summary/<path:path_to>/',
+    '/summary/<string:packagename>/<string:version>/',
     view_func=SummaryView.as_view(
         'summary',
         render_func=bind_render('patches/summary.html'),
@@ -118,7 +113,7 @@ bp_patches.add_url_rule(
 
 # api
 bp_patches.add_url_rule(
-    '/api/summary/<path:path_to>/',
+    '/api/summary/<string:packagename>/<string:version>/',
     view_func=SummaryView.as_view(
         'api_summary',
         render_func=jsonify,

--- a/debsources/app/patches/routes.py
+++ b/debsources/app/patches/routes.py
@@ -89,7 +89,7 @@ bp_patches.add_url_rule(
 
 # VERSIONSVIEW
 bp_patches.add_url_rule(
-    '/summary/<string:packagename>/',
+    '/<string:packagename>/',
     view_func=VersionsView.as_view(
         'versions',
         render_func=bind_render('patches/package.html'),
@@ -97,7 +97,7 @@ bp_patches.add_url_rule(
 
 # api
 bp_patches.add_url_rule(
-    '/api/summary/<string:packagename>/',
+    '/api/<string:packagename>/',
     view_func=VersionsView.as_view(
         'api_patch_versions',
         render_func=jsonify,
@@ -105,7 +105,7 @@ bp_patches.add_url_rule(
 
 # SUMMARYVIEW
 bp_patches.add_url_rule(
-    '/summary/<string:packagename>/<string:version>/',
+    '/<string:packagename>/<string:version>/',
     view_func=SummaryView.as_view(
         'summary',
         render_func=bind_render('patches/summary.html'),
@@ -113,7 +113,7 @@ bp_patches.add_url_rule(
 
 # api
 bp_patches.add_url_rule(
-    '/api/summary/<string:packagename>/<string:version>/',
+    '/api/<string:packagename>/<string:version>/',
     view_func=SummaryView.as_view(
         'api_summary',
         render_func=jsonify,
@@ -150,17 +150,17 @@ bp_patches.add_url_rule(
 
 # PATCHVIEW
 bp_patches.add_url_rule(
-    '/patch/<path:path_to>/',
+    '/<string:packagename>/<string:version>/<path:path_to>/',
     view_func=PatchView.as_view(
-        'patch',
+        'patch_view',
         render_func=bind_render('patches/patch.html'),
         err_func=ErrorHandler('patches')))
 
 # api
 bp_patches.add_url_rule(
-    '/api/patch/<path:path_to>/',
+    '/api/<string:packagename>/<string:version>/<path:path_to>/',
     view_func=PatchView.as_view(
-        'api_patch',
+        'api_patch_view',
         render_func=jsonify,
         err_func=ErrorHandler(mode='json')))
 

--- a/debsources/app/patches/templates/patches/404_suggestions.html
+++ b/debsources/app/patches/templates/patches/404_suggestions.html
@@ -7,11 +7,11 @@
 
 <p>The specific version of the package you requested doesn't exist,
 but other versions of this package are available in the database.
-The license you are looking for might exist in one of the following
+The summary you are looking for might exist in one of the following
 versions:
 <ul>
 {% for s in suggestions %}
-  <li><a href="{{ url_for('.summary', path_to=s) }}">{{ s }}</a></li>
+  <li><a href="{{ url_for('.summary', packagename=s.split('/')[0], version=s.split('/')[1]) }}">{{ '/'.join(s.split('/')[0:2]) }}</a></li>
 {% endfor %}
 </ul>
 </p>

--- a/debsources/app/patches/templates/patches/doc_api.html
+++ b/debsources/app/patches/templates/patches/doc_api.html
@@ -51,18 +51,18 @@
 <h4>Package summary</h4>
 <p>
   You can retrieve a summary for a package:
-  <span class="url">{{ url_prefix }}/api/summary/<strong>packagename</strong>/<strong>version</strong></span>
+  <span class="url">{{ url_prefix }}/api/<strong>packagename</strong>/<strong>version</strong></span>
   The package summary contains the names of the patches and some basic information about the package
   <br/>
-  <a href="{{ url_prefix }}/api/summary/beignet/1.0.0-1/">example</a>
+  <a href="{{ url_prefix }}/api/beignet/1.0.0-1/">example</a>
 
 <h4>Patch view</h4>
 <p>
   The URL for a patch view is:
-  <span class="url">{{ url_prefix }}/api/patch/<strong>packagename</strong>/<strong>version</strong>/<strong>path</strong></span>
+  <span class="url">{{ url_prefix }}/api/<strong>packagename</strong>/<strong>version</strong>/<strong>path</strong></span>
   Both package name and version are required parameters. The path is the relative path of the patch starting from the debian/patches directory.<br />
   This query retrieves the file-deltas, the description and the bug number if they exist.
-  <a href="{{ url_prefix }}/api/patch/beignet/1.0.0-1/Debian-compliant-compiler-flags-handling.patch/">See example</a>
+  <a href="{{ url_prefix }}/api/beignet/1.0.0-1/Debian-compliant-compiler-flags-handling.patch/">See example</a>
 </p>
 
 <h3>Package list</h3>

--- a/debsources/app/patches/templates/patches/doc_url.html
+++ b/debsources/app/patches/templates/patches/doc_url.html
@@ -39,18 +39,18 @@
 <p>
   The URL for the patches summary of a package is:
   <span class="url">{{ url_prefix
-  }}/summary/<strong>packagename</strong>/<strong>version</strong></span>
+  }}/<strong>packagename</strong>/<strong>version</strong></span>
   Version can be a suite name, a version number or the keyword 'latest'
-  <a href="{{ url_prefix }}/summary/beignet/1.0.0-1/">See example</a>
+  <a href="{{ url_prefix }}/beignet/1.0.0-1/">See example</a>
 </p>
 
 <h4>Patch view</h4>
 <p>
   The URL for displaying patch information is:
   <span class="url">{{ url_prefix
-  }}/patch/<strong>packagename</strong>/<strong>version</strong>/<strong>path</strong></span>
+  }}/<strong>packagename</strong>/<strong>version</strong>/<strong>path</strong></span>
   Both package name and version are required parameters. The path is the relative path of the patch starting from the debian/patches directory.
-  <a href="{{ url_prefix }}/patch/beignet/1.0.0-1/Debian-compliant-compiler-flags-handling.patch/">See example</a>
+  <a href="{{ url_prefix }}/beignet/1.0.0-1/Debian-compliant-compiler-flags-handling.patch/">See example</a>
 </p>
 
 <h3>Package list</h3>
@@ -92,5 +92,6 @@
   <a href="{{ url_prefix }}/license/ocaml?suite=squeeze">See example</a>
 </p>
 
+<p>Package versions with no links signify that the patch format <strong>is not 3.0 quilt</strong>.<br />The <strong>asterisk (*)</strong> at a package versions implies that although the patch format is 3.0 quilt, the specific version has no patches yet.</p>
 
 {% endblock %}

--- a/debsources/app/patches/templates/patches/package.html
+++ b/debsources/app/patches/templates/patches/package.html
@@ -5,7 +5,7 @@
   License: GNU Affero General Public License, version 3 or above.
 #}
 {# copied from templates/source_base.html #}
-{% extends "sources/source_base.html" %}
+{% extends name+"/source_base.html" %}
 
 {% block head %}
 {{ super() }}
@@ -13,11 +13,33 @@
       href="{{ url_for('sources.static', filename='css/source_folder.css') }}" />
 {% endblock %}
 
+{% block breadcrumbs %}<a href="{{ url_for('.index') }}">{{ request.blueprint }}</a> /{% endblock %}
+
 {% block title %}Package: {{ package }}{% endblock %}
 {% block source_content %}
 <h2>{{ self.title() }}</h2>
 {{ macros.show_suite(suite) }}
 
-{{ macros.show_versions(versions, path, '.summary', config['ICONS_FOLDER'])}}
+<ul id="ls">
+  {% for v in versions %}
+  <li>{%- if v.supported == true %}<a href="{{ url_for('.summary', packagename=package, version=v.version) }}">{{ v.version }}</a>
+      {%- else %}
+        {{ v.version }}
+      {%- endif %}
+    ({{ v.area }})
+    {% if v.suites %}
+        [{{ ", ".join(v.suites) }}]
+    {% endif %}
+    {%- if v.supported == true %}
+      {%- if v.series == 0 %}
+        <strong>*</strong>
+      {%- endif %}
+    {%- endif %}
+  </li>
+  {% endfor %}
+  </ul>
+  {% if is_empty == true %}
+    <p>* This package has no patches yet.</p>
+  {% endif %}
 
 {% endblock %}

--- a/debsources/app/patches/templates/patches/patch.html
+++ b/debsources/app/patches/templates/patches/patch.html
@@ -15,7 +15,7 @@
         href="{{ config.HIGHLIGHT_JS_FOLDER }}/styles/{{ config.HIGHLIGHT_STYLE }}.css">
   <script src="{{ config.HIGHLIGHT_JS_FOLDER }}/highlight.min.js"></script> 
 {% endblock %}
-{% block breadcrumbs %} <a href='{{ url_for(".index") }}'>Patches</a> / Patch / <a href="{{ url_for('.versions', packagename=package) }}">{{ package }}</a> / <a href="{{ url_for('.summary', path_to=package + '/' + version) }}">{{ version }}</a>
+{% block breadcrumbs %} <a href='{{ url_for(".index") }}'>Patches</a> / Patch / <a href="{{ url_for('.versions', packagename=package) }}">{{ package }}</a> / <a href="{{ url_for('.summary', packagename=package, version=version) }}">{{ version }}</a>
 {% endblock %}
 {% block title %}Package: {{ package }}{% endblock %}
 {% block content %}

--- a/debsources/app/patches/templates/patches/summary.html
+++ b/debsources/app/patches/templates/patches/summary.html
@@ -56,7 +56,7 @@
           <p>Bug: <a href="https://bugs.debian.org/{{patches[patch]['bug']}}">#{{patches[patch]['bug']}}</a></p>   
           {%- endif %}
           </td>
-          <td><a href="{{ url_for('.patch', path_to=path + '/' +patch.rstrip().split(' ')[0])}}">View</a></td>
+          <td><a href="{{ url_for('.patch_view', packagename=package, version=version, path_to=patch.rstrip().split(' ')[0])}}">View</a></td>
           <td><a href="{{ patches[patch]['download'] }}">download</a></td>
         </tr>
         {% endfor %}

--- a/debsources/app/patches/views.py
+++ b/debsources/app/patches/views.py
@@ -124,12 +124,15 @@ class SummaryView(GeneralView):
         try:
             format_file = helper.get_patch_format(session, packagename,
                                                   version, current_app.config)
-        except FileOrFolderNotFound:
-            return dict(package=packagename,
-                        version=version,
-                        path=path_to,
-                        patches=[],
-                        format='unknown')
+        except (FileOrFolderNotFound, InvalidPackageOrVersionError) as e:
+            if isinstance(e, InvalidPackageOrVersionError):
+                raise Http404ErrorSuggestions(packagename, version, '')
+            else:
+                return dict(package=packagename,
+                            version=version,
+                            path=path_to,
+                            patches=[],
+                            format='unknown')
         if not helper.is_supported(format_file.rstrip()):
             return dict(package=packagename,
                         version=version,

--- a/debsources/app/patches/views.py
+++ b/debsources/app/patches/views.py
@@ -11,20 +11,57 @@
 
 from __future__ import absolute_import
 
-import io
-
 from flask import request, current_app
 
 from ..views import GeneralView, session
-from debsources.navigation import Location, SourceFile
 from debsources.excepts import (Http404ErrorSuggestions, FileOrFolderNotFound,
-                                InvalidPackageOrVersionError)
+                                InvalidPackageOrVersionError, Http404Error)
+import debsources.query as qry
 from ..sourcecode import SourceCodeIterator
 from . import patches_helper as helper
 
 
-ACCEPTED_FORMATS = ['3.0 (quilt)',
-                    '3.0 (native)']
+class VersionsView(GeneralView):
+    def get_objects(self, packagename):
+        suite = request.args.get("suite") or ""
+        suite = suite.lower()
+        if suite == "all":
+            suite = ""
+        # we list the version with suites it belongs to
+        try:
+            versions_w_suites = qry.pkg_names_list_versions_w_suites(
+                session, packagename, suite, reverse=True)
+        except InvalidPackageOrVersionError:
+            raise Http404Error("%s not found" % packagename)
+        empty = False
+        for i, v in enumerate(versions_w_suites):
+            try:
+                format_file = helper.get_patch_format(session, packagename,
+                                                      v['version'],
+                                                      current_app.config)
+            except FileOrFolderNotFound:
+                format_file = ""
+                versions_w_suites[i]['supported'] = False
+            if not helper.is_supported(format_file.rstrip()):
+                versions_w_suites[i]['supported'] = False
+            else:
+                versions_w_suites[i]['supported'] = True
+                try:
+                    series = helper.get_patch_series(session, packagename,
+                                                     v['version'],
+                                                     current_app.config)
+                except (FileOrFolderNotFound, InvalidPackageOrVersionError):
+                    series = []
+                if len(series) == 0:
+                    empty = True
+                versions_w_suites[i]['series'] = len(series)
+
+        return dict(type="package",
+                    package=packagename,
+                    versions=versions_w_suites,
+                    path=packagename,
+                    suite=suite,
+                    is_empty=empty)
 
 
 class SummaryView(GeneralView):
@@ -52,11 +89,9 @@ class SummaryView(GeneralView):
             if not serie.startswith('#'):
                 patch = serie.rstrip().split(' ')[0]
                 try:
-                    serie_path, loc = get_sources_path(session, package,
-                                                       version,
-                                                       current_app.config,
-                                                       'debian/patches/'
-                                                       + patch)
+                    serie_path, loc = helper.get_sources_path(
+                        session, package, version, current_app.config,
+                        'debian/patches/' + patch)
                     summary = helper.get_file_deltas(serie_path)
                     deltas, deltas_summary = self._parse_file_deltas(summary,
                                                                      package,
@@ -73,41 +108,30 @@ class SummaryView(GeneralView):
                                                bug='')
         return patches_info
 
-    def get_objects(self, path_to):
-        path_dict = path_to.split('/')
-        package = path_dict[0]
-        version = path_dict[1]
-
-        if len(path_dict) > 2:
-            raise Http404ErrorSuggestions(package, version, '')
-
+    def get_objects(self, packagename, version):
+        path_to = packagename + '/' + version
         if version == "latest":  # we search the latest available version
             return self._handle_latest_version(request.endpoint,
-                                               package, "")
+                                               packagename, "")
 
-        versions = self.handle_versions(version, package, "")
+        versions = self.handle_versions(version, packagename, "")
         if versions:
-            redirect_url_parts = [package, versions[-1]]
+            redirect_url_parts = [packagename, versions[-1]]
             redirect_url = '/'.join(redirect_url_parts)
             return self._redirect_to_url(request.endpoint,
                                          redirect_url, redirect_code=302)
 
-        # identify patch format, accept only 3.0 quilt
         try:
-            source_format, loc = get_sources_path(session, package, version,
-                                                  current_app.config,
-                                                  'debian/source/format')
-        except (FileOrFolderNotFound, InvalidPackageOrVersionError):
-            return dict(package=package,
+            format_file = helper.get_patch_format(session, packagename,
+                                                  version, current_app.config)
+        except FileOrFolderNotFound:
+            return dict(package=packagename,
                         version=version,
                         path=path_to,
                         patches=[],
                         format='unknown')
-
-        with io.open(source_format, mode='r', encoding='utf-8') as f:
-            format_file = f.read()
-        if format_file.rstrip() not in ACCEPTED_FORMATS:
-            return dict(package=package,
+        if not helper.is_supported(format_file.rstrip()):
+            return dict(package=packagename,
                         version=version,
                         path=path_to,
                         format=format_file,
@@ -116,53 +140,30 @@ class SummaryView(GeneralView):
 
         # are there any patches for the package?
         try:
-            series, loc = get_sources_path(session, package, version,
-                                           current_app.config,
-                                           'debian/patches/series')
+            series = helper.get_patch_series(session, packagename, version,
+                                             current_app.config)
         except (FileOrFolderNotFound, InvalidPackageOrVersionError):
-            return dict(package=package,
+            return dict(package=packagename,
                         version=version,
                         path=path_to,
                         format=format_file,
                         patches=[],
                         supported=True)
-        with io.open(series, mode='r', encoding='utf-8') as f:
-            series = f.readlines()
 
-        info = self.parse_patch_series(session, package, version,
+        info = self.parse_patch_series(session, packagename, version,
                                        current_app.config, series)
         if 'api' in request.endpoint:
-            return dict(package=package,
+            return dict(package=packagename,
                         version=version,
                         format=format_file.rstrip(),
                         patches=[key.rstrip() for key in info.keys()])
-        return dict(package=package,
+        return dict(package=packagename,
                     version=version,
                     path=path_to,
                     format=format_file,
                     series=info.keys(),
                     patches=info,
                     supported=True)
-
-
-def get_sources_path(session, package, version, config, path):
-    ''' Creates a sources_path. Returns exception when it arises
-    '''
-    try:
-        location = Location(session,
-                            config["SOURCES_DIR"],
-                            config["SOURCES_STATIC"],
-                            package, version, path)
-    except (FileOrFolderNotFound, InvalidPackageOrVersionError) as e:
-        raise e
-
-    file_ = SourceFile(location)
-
-    sources_path = file_.get_raw_url().replace(
-        config['SOURCES_STATIC'],
-        config['SOURCES_DIR'],
-        1)
-    return sources_path, file_
 
 
 class PatchView(GeneralView):
@@ -188,10 +189,9 @@ class PatchView(GeneralView):
                                          redirect_code=302)
 
         try:
-            serie_path, loc = get_sources_path(session, package, version,
-                                               current_app.config,
-                                               'debian/patches/'
-                                               + patch.rstrip())
+            serie_path, loc = helper.get_sources_path(
+                session, package, version, current_app.config,
+                'debian/patches/' + patch.rstrip())
         except (FileOrFolderNotFound, InvalidPackageOrVersionError):
             raise Http404ErrorSuggestions(package, version, 'debian/patches/'
                                                             + patch.rstrip())

--- a/debsources/app/views.py
+++ b/debsources/app/views.py
@@ -208,12 +208,22 @@ class GeneralView(View):
             self.render_func = bind_redirect(url_for(endpoint,
                                              packagename=redirect_url),
                                              code=redirect_code)
-        elif endpoint == 'patches.summary':
+        elif 'summary' in endpoint or 'license' in endpoint:
             package, version = redirect_url.split('/')
             self.render_func = bind_redirect(url_for(endpoint,
-                                             packagename=package,
-                                             version=version,
-                                             code=redirect_code))
+                                                     packagename=package,
+                                                     version=version),
+                                             code=redirect_code)
+        elif 'patch_view' in endpoint:
+            parts = redirect_url.split('/')
+            package = parts[0]
+            version = parts[1]
+            path = '/'.join(parts[2:])
+            self.render_func = bind_redirect(url_for(endpoint,
+                                                     packagename=package,
+                                                     version=version,
+                                                     path_to=path),
+                                             code=redirect_code)
         else:
             self.render_func = bind_redirect(url_for(endpoint,
                                              path_to=redirect_url),
@@ -544,9 +554,7 @@ class PackageVersionsView(GeneralView):
         if request.blueprint == 'sources':
             endpoint = '.source'
         elif request.blueprint == 'copyright':
-            endpoint = '.license'
-        elif request.blueprint == 'patches':
-            endpoint = '.summary'
+            endpoint = '.versions'
 
         pathl = qry.location_get_path_links(endpoint, packagename)
         return dict(type="package",

--- a/debsources/app/views.py
+++ b/debsources/app/views.py
@@ -208,6 +208,12 @@ class GeneralView(View):
             self.render_func = bind_redirect(url_for(endpoint,
                                              packagename=redirect_url),
                                              code=redirect_code)
+        elif endpoint == 'patches.summary':
+            package, version = redirect_url.split('/')
+            self.render_func = bind_redirect(url_for(endpoint,
+                                             packagename=package,
+                                             version=version,
+                                             code=redirect_code))
         else:
             self.render_func = bind_redirect(url_for(endpoint,
                                              path_to=redirect_url),

--- a/debsources/query.py
+++ b/debsources/query.py
@@ -121,10 +121,15 @@ def location_get_path_links(endpoint, path_to):
     # can run in another machine without flask, because it doesn't use
     # this method)
     from flask import url_for
-
-    for (i, p) in enumerate(path_dict):
-        pathl.append((p, url_for(endpoint,
-                                 path_to='/'.join(path_dict[:i + 1]))))
+    print path_dict
+    if endpoint == '.versions':
+        for (i, p) in enumerate(path_dict):
+            pathl.append((p, url_for(endpoint,
+                                     packagename='/'.join(path_dict[:i + 1]))))
+    else:
+        for (i, p) in enumerate(path_dict):
+            pathl.append((p, url_for(endpoint,
+                                     path_to='/'.join(path_dict[:i + 1]))))
     return pathl
 
 

--- a/debsources/tests/test_web_cp.py
+++ b/debsources/tests/test_web_cp.py
@@ -323,13 +323,6 @@ class CopyrightTestCase(DebsourcesBaseWebTests, unittest.TestCase):
                    "rce.org/licenses/GPL-3.0\">GPL-3+</a>"
         self.assertIn(synopsis, rv.data)
 
-    def test_license_404(self):
-        rv = self.app.get("/copyright/license/gnubg/1.02.000-2/foo",
-                          follow_redirects=True)
-        self.assertIn('other versions of this package are available', rv.data)
-        link = '<a href="/copyright/license/gnubg/0.90+20091206-4/">'
-        self.assertIn(link, rv.data)
-
 
 if __name__ == '__main__':
     unittest.main(exit=False)

--- a/debsources/tests/test_web_patches.py
+++ b/debsources/tests/test_web_patches.py
@@ -52,40 +52,40 @@ class CopyrightTestCase(DebsourcesBaseWebTests, unittest.TestCase):
 
     def test_by_prefix(self):
         rv = self.app.get('/patches/prefix/libc/')
-        self.assertIn("/summary/libcaca", rv.data)
+        self.assertIn("/libcaca", rv.data)
         # suite specified
         rv = self.app.get('/patches/prefix/libc/?suite=squeeze')
-        self.assertIn("/summary/libcaca", rv.data)
+        self.assertIn("/libcaca", rv.data)
         # a non-existing suite specified
         rv = self.app.get(
             '/patches/prefix/libc/?suite=non-existing')
-        self.assertNotIn("/summary/libcaca", rv.data)
+        self.assertNotIn("/libcaca", rv.data)
         # special suite name "all" is specified
         rv = self.app.get(
             '/patches/prefix/libc/?suite=all')
-        self.assertIn("/summary/libcaca", rv.data)
+        self.assertIn("/libcaca", rv.data)
 
     def test_latest(self):
-        rv = self.app.get('/patches/summary/gnubg/latest/',
+        rv = self.app.get('/patches/gnubg/latest/',
                           follow_redirects=True)
         self.assertIn("Package: gnubg / 1.02.000-2", rv.data)
-        rv = self.app.get('/patches/patch/beignet/latest/'
+        rv = self.app.get('/patches/beignet/latest/'
                           'Enable-test-debug.patch/',
                           follow_redirects=True)
         self.assertIn('<code id="sourcecode" class="diff">', rv.data)
 
     def test_package_summary(self):
-        rv = self.app.get('/patches/summary/beignet/1.0.0-1/')
+        rv = self.app.get('/patches/beignet/1.0.0-1/')
         self.assertIn("Enhance debug output", rv.data)
         self.assertIn("utests/builtin_acos_asin.cpp</a> |    8 +++++---",
                       rv.data)
 
         # test non quilt package
-        rv = self.app.get('/patches/summary/cvsnt/2.5.03.2382-3/')
+        rv = self.app.get('/patches/cvsnt/2.5.03.2382-3/')
         self.assertIn("The format of the patches in the package", rv.data)
 
     def test_view_patch(self):
-        rv = self.app.get('/patches/patch/beignet/1.0.0-1/'
+        rv = self.app.get('/patches/beignet/1.0.0-1/'
                           'Enable-test-debug.patch/')
         self.assertIn('<code id="sourcecode" class="diff">', rv.data)
         # highlight inside?
@@ -93,40 +93,40 @@ class CopyrightTestCase(DebsourcesBaseWebTests, unittest.TestCase):
         self.assertIn('highlight/highlight.min.js"></script>', rv.data)
 
     def test_file_deltas_links(self):
-        rv = self.app.get('/patches/summary/beignet/1.0.0-1/')
+        rv = self.app.get('/patches/beignet/1.0.0-1/')
         self.assertIn('<a href="/src/beignet/1.0.0-1/src/cl_utils.h/">',
                       rv.data)
 
     def test_3_native_format(self):
-        rv = self.app.get("/patches/summary/nvidia-support/20131102+1/")
+        rv = self.app.get("/patches/nvidia-support/20131102+1/")
         self.assertIn('<td>3.0 (native)</td>', rv.data)
         self.assertIn('<p>This package has no patches.</p>', rv.data)
         self.assertNotIn('The format of the patches in the package', rv.data)
 
     def test_bts_link(self):
-        rv = self.app.get('/patches/summary/ledit/2.03-2/')
+        rv = self.app.get('/patches/ledit/2.03-2/')
         self.assertIn('<a href="https://bugs.debian.org/672479">#672479</a>',
                       rv.data)
         # test no bug
-        rv = self.app.get('/patches/summary/gnubg/1.02.000-2/')
+        rv = self.app.get('/patches/gnubg/1.02.000-2/')
         self.assertNotIn('Bug: ', rv.data)
 
     def test_extract_description(self):
-        rv = self.app.get('/patches/summary/gnubg/1.02.000-2/')
+        rv = self.app.get('/patches/gnubg/1.02.000-2/')
         self.assertIn('collected debian patches for gnubg', rv.data)
         # test long dsc
-        rv = self.app.get('/patches/summary/beignet/1.0.0-1/')
+        rv = self.app.get('/patches/beignet/1.0.0-1/')
         long_dsc = 'Turn on udebug so tests print their full output, and mark' \
                    ' failures\nby &#34;failed:&#34; instead of invisible-in-' \
                    'logs colour.'
         self.assertIn(long_dsc, rv.data)
         # test no description header
-        rv = self.app.get('/patches/summary/unrar-nonfree/1:5.0.10-1/')
+        rv = self.app.get('/patches/unrar-nonfree/1:5.0.10-1/')
         self.assertIn('fix buildflags', rv.data)
         self.assertIn('---', rv.data)
 
     def test_api_patch_view(self):
-        rv = json.loads(self.app.get('/patches/api/patch/beignet/1.0.0-1/'
+        rv = json.loads(self.app.get('/patches/api/beignet/1.0.0-1/'
                         'Enable-test-debug.patch/').data)
         self.assertEqual(rv['name'], 'Enable-test-debug.patch')
         self.assertEqual(rv['bug'], '')
@@ -137,7 +137,7 @@ class CopyrightTestCase(DebsourcesBaseWebTests, unittest.TestCase):
 
     def test_api_summary_view(self):
         rv = json.loads(
-            self.app.get('/patches/api/summary/beignet/1.0.0-1/').data)
+            self.app.get('/patches/api/beignet/1.0.0-1/').data)
         patches = ["Debian-compliant-compiler-flags-handling.patch",
                    "Enhance-debug-output.patch",
                    "Utest-requires-deprecated-function-names.patch",

--- a/debsources/tests/test_web_patches.py
+++ b/debsources/tests/test_web_patches.py
@@ -97,13 +97,6 @@ class CopyrightTestCase(DebsourcesBaseWebTests, unittest.TestCase):
         self.assertIn('<a href="/src/beignet/1.0.0-1/src/cl_utils.h/">',
                       rv.data)
 
-    def test_summary_404(self):
-        rv = self.app.get("/patches/summary/gnubg/1.02.000-2/foo",
-                          follow_redirects=True)
-        self.assertIn('other versions of this package are available', rv.data)
-        link = '<a href="/patches/summary/gnubg/0.90+20091206-4/">'
-        self.assertIn(link, rv.data)
-
     def test_3_native_format(self):
         rv = self.app.get("/patches/summary/nvidia-support/20131102+1/")
         self.assertIn('<td>3.0 (native)</td>', rv.data)


### PR DESCRIPTION
So this PR does the following:
- refactor the versions view for the patch tracker. So now the routes have slightly changed /summary/:package/:version instead of a /summary/:path. and also implemented the proposal for the versions view (no link when format is not 3.0 quilt and \* for no patches).
- refactor the versions of the copyright tracker to drop the folder icon and also modify routes to be /:package/:version instead of /:path for the license view.  
- Then again some refactoring to drop the /summary and /path prefix.
- I also fixed an issue i found in the patch tracker. 

Warnings:
- documentation for versions view. If we merge this PR first then i have to modify PR#41 or the other way around.
- Still need to be decided: icons for the patch and copyright tracker
