### PR TITLE
patches: preserve order of patches as found in patches/series

### DIFF
--- a/debsources/app/patches/views.py
+++ b/debsources/app/patches/views.py
@@ -12,6 +12,7 @@
 from __future__ import absolute_import
 
 import io
+from collections import OrderedDict
 
 from flask import request, current_app
 
@@ -47,7 +48,7 @@ class SummaryView(GeneralView):
             changes.
 
         """
-        patches_info = dict()
+        patches_info = OrderedDict()
         for serie in series:
             serie = serie.strip()
             if not serie.startswith('#') and not serie == "":
@@ -136,7 +137,7 @@ class SummaryView(GeneralView):
             return dict(package=package,
                         version=version,
                         format=format_file.rstrip(),
-                        patches=sorted([key.rstrip() for key in info.keys()]))
+                        patches=[key.rstrip() for key in info.keys()])
         return dict(package=package,
                     version=version,
                     path=path_to,

--- a/debsources/tests/test_web_patches.py
+++ b/debsources/tests/test_web_patches.py
@@ -145,11 +145,11 @@ class CopyrightTestCase(DebsourcesBaseWebTests, unittest.TestCase):
     def test_api_summary_view(self):
         rv = json.loads(
             self.app.get('/patches/api/summary/beignet/1.0.0-1/').data)
-        patches = ["Debian-compliant-compiler-flags-handling.patch",
-                   "Enable-test-debug.patch",
-                   "Enhance-debug-output.patch",
+        patches = ["Enhance-debug-output.patch",
+                   "Debian-compliant-compiler-flags-handling.patch",
+                   "Utest-requires-deprecated-function-names.patch",
                    "Link-against-terminfo.patch",
-                   "Utest-requires-deprecated-function-names.patch"]
+                   "Enable-test-debug.patch"]
         self.assertListEqual(patches, rv['patches'])
         self.assertEqual(rv['format'], "3.0 (quilt)")
 


### PR DESCRIPTION
Use an ordered dict to preserve the order of the patches as we
read it from the patches/series.
