### PR TITLE
Fixes templates

### DIFF
--- a/debsources/app/copyright/templates/copyright/doc_api.html
+++ b/debsources/app/copyright/templates/copyright/doc_api.html
@@ -4,8 +4,6 @@
   https://anonscm.debian.org/gitweb/?p=qa/debsources.git;a=blob;f=AUTHORS;hb=HEAD
   License: GNU Affero General Public License, version 3 or above.
 #}
-
-{% block content %}
 {% set url_prefix = "//" + config.SOURCES_URL + '/copyright' %}
 
 <h2 id='copyright'>Copyright</h2>
@@ -80,5 +78,3 @@ Package and suite parameters are optional.
   <span class="url">{{ url_prefix }}/api/ping/</span>
   <a href="{{ url_prefix }}/api/ping">example</a>
 </p>
-
-{% endblock %}

--- a/debsources/app/copyright/templates/copyright/doc_url.html
+++ b/debsources/app/copyright/templates/copyright/doc_url.html
@@ -4,7 +4,6 @@
   https://anonscm.debian.org/gitweb/?p=qa/debsources.git;a=blob;f=AUTHORS;hb=HEAD
   License: GNU Affero General Public License, version 3 or above.
 #}
-{% block content %}
 {% set url_prefix = "//" + config.SOURCES_URL + '/copyright' %}
 
 <h2 id='copyright'>Copyright</h2>
@@ -84,6 +83,3 @@ otherwise it provides a text dump.
   <a href="{{ url_prefix }}/license/cowsay/squeeze/">See example</a> and
   <a href="{{ url_prefix }}/license/cowsay/latest/"> another one</a>.
 </p>
-
-
-{% endblock %}

--- a/debsources/app/copyright/templates/copyright/index.html
+++ b/debsources/app/copyright/templates/copyright/index.html
@@ -27,13 +27,13 @@
   <tr>
     <td id="browse">
       <p><strong>Browse</strong> by prefix</p>
-      <p>{{ macros.render_packages_prefixes(packages_prefixes) }}</p>
+      <p>{{ macros.render_packages_prefixes(packages_prefixes, request) }}</p>
     </td>
     <td id="search">
       <p><strong>Search</strong></p>
       <ul style="list-style-type: none">
   <li>by <em>package name</em>:<br />
-	  {{ macros.searchform(searchform, value=query, display="inline", size="25", autofocus=True, id="query-2") }}
+	  {{ macros.searchform(searchform, request, value=query, display="inline", size="25", autofocus=True, id="query-2") }}
 	</li>
       </ul>
     </td>

--- a/debsources/app/patches/templates/patches/doc_api.html
+++ b/debsources/app/patches/templates/patches/doc_api.html
@@ -4,8 +4,6 @@
   https://anonscm.debian.org/gitweb/?p=qa/debsources.git;a=blob;f=AUTHORS;hb=HEAD
   License: GNU Affero General Public License, version 3 or above.
 #}
-
-{% block content %}
 {% set url_prefix = "//" + config.SOURCES_URL + '/patches' %}
 
 <h2 id='patches'>Patches</h2>
@@ -61,5 +59,3 @@
   <span class="url">{{ url_prefix }}/api/ping/</span>
   <a href="{{ url_prefix }}/api/ping">example</a>
 </p>
-
-{% endblock %}

--- a/debsources/app/patches/templates/patches/doc_url.html
+++ b/debsources/app/patches/templates/patches/doc_url.html
@@ -4,8 +4,6 @@
   https://anonscm.debian.org/gitweb/?p=qa/debsources.git;a=blob;f=AUTHORS;hb=HEAD
   License: GNU Affero General Public License, version 3 or above.
 #}
-
-{% block content %}
 {% set url_prefix = "//" + config.SOURCES_URL + '/patches' %}
 
 <h2 id='patches'>Patches</h2>
@@ -68,5 +66,3 @@
 </p>
 
 <p>Package versions with no links signify that the patch format <strong>is not 3.0 quilt</strong>.<br />The <strong>asterisk (*)</strong> at a package versions implies that although the patch format is 3.0 quilt, the specific version has no patches yet.</p>
-
-{% endblock %}

--- a/debsources/app/patches/templates/patches/index.html
+++ b/debsources/app/patches/templates/patches/index.html
@@ -27,13 +27,13 @@
   <tr>
     <td id="browse">
       <p><strong>Browse</strong> by prefix</p>
-      <p>{{ macros.render_packages_prefixes(packages_prefixes) }}</p>
+      <p>{{ macros.render_packages_prefixes(packages_prefixes, request) }}</p>
     </td>
     <td id="search">
       <p><strong>Search</strong></p>
       <ul style="list-style-type: none">
   <li>by <em>package name</em>:<br />
-	  {{ macros.searchform(searchform, value=query, display="inline", size="25", autofocus=True, id="query-2") }}
+	  {{ macros.searchform(searchform, request, value=query, display="inline", size="25", autofocus=True, id="query-2") }}
 	</li>
       </ul>
     </td>

--- a/debsources/app/sources/templates/sources/doc_api.html
+++ b/debsources/app/sources/templates/sources/doc_api.html
@@ -4,8 +4,6 @@
   https://anonscm.debian.org/gitweb/?p=qa/debsources.git;a=blob;f=AUTHORS;hb=HEAD
   License: GNU Affero General Public License, version 3 or above.
 #}
-
-{% block content %}
 {% set url_prefix = "//" + config.SOURCES_URL %}
 <h2 id='sources'>Sources</h2>
 
@@ -104,4 +102,3 @@
   <span class="url">{{ url_prefix }}/api/ping/</span>
   <a href="{{ url_prefix }}/api/ping">example</a>
 </p>
-{% endblock %}

--- a/debsources/app/sources/templates/sources/doc_url.html
+++ b/debsources/app/sources/templates/sources/doc_url.html
@@ -4,8 +4,6 @@
   https://anonscm.debian.org/gitweb/?p=qa/debsources.git;a=blob;f=AUTHORS;hb=HEAD
   License: GNU Affero General Public License, version 3 or above.
 #}
-
-{% block content %}
 {% set url_prefix = "//" + config.SOURCES_URL %}
 
 <h2 id='sources'>Sources</h2>
@@ -169,5 +167,3 @@
   <span class="url">{{ url_prefix
   }}/embed/pkginfo/<strong>packagename</strong>/<strong>version</strong></span>
 </p>
-
-{% endblock %}

--- a/debsources/app/sources/templates/sources/index.html
+++ b/debsources/app/sources/templates/sources/index.html
@@ -27,13 +27,13 @@
   <tr>
     <td id="browse">
       <p><strong>Browse</strong> by prefix</p>
-      <p>{{ macros.render_packages_prefixes(packages_prefixes) }}</p>
+      <p>{{ macros.render_packages_prefixes(packages_prefixes, request) }}</p>
     </td>
     <td id="search">
       <p><strong>Search</strong></p>
       <ul style="list-style-type: none">
 	<li>by <em>package name</em>:<br />
-	  {{ macros.searchform(searchform, value=query, display="inline", size="25", autofocus=True, id="query-2") }}
+	  {{ macros.searchform(searchform, request, value=query, display="inline", size="25", autofocus=True, id="query-2") }}
 	</li>
 	<li>the <em>source code</em>
 	  <small>(via <a href="https://codesearch.debian.net">codesearch</a>)</small>:<br />

--- a/debsources/app/templates/_macros.html
+++ b/debsources/app/templates/_macros.html
@@ -32,7 +32,7 @@ https://pythonhosted.org/Flask-SQLAlchemy/api.html#flask.ext.sqlalchemy.Paginati
   </div>
 {%- endmacro %}
 
-{% macro searchform(form, display="block") -%}
+{% macro searchform(form, request, display="block") -%}
   {% if request.blueprint == 'doc' %}
     {% set endpoint = 'sources.recv_search' %}
   {% else %}
@@ -51,7 +51,7 @@ https://pythonhosted.org/Flask-SQLAlchemy/api.html#flask.ext.sqlalchemy.Paginati
 {%- endmacro %}
 
 
-{% macro render_packages_prefixes(prefixes) %}
+{% macro render_packages_prefixes(prefixes, request) %}
 {% if request.blueprint == 'doc' %}
     {% set endpoint = 'sources.prefix' %}
   {% else %}

--- a/debsources/app/templates/base.html
+++ b/debsources/app/templates/base.html
@@ -30,7 +30,7 @@
         </div> <!-- end logo -->
         <p class="section"><a href="{{ url_for('sources.index') }}">DEBSOURCES</a></p>
         <div id="searchbox">
-            {{ macros.searchform(searchform, display="inline", value=query, placeholder="package name", id="query-1") }}
+            {{ macros.searchform(searchform, request, display="inline", value=query, placeholder="package name", id="query-1") }}
             <form name="codesearch" method="get"
             action="https://codesearch.debian.net/search">
               <input name="q"

--- a/debsources/app/templates/footer.inc.html
+++ b/debsources/app/templates/footer.inc.html
@@ -6,7 +6,7 @@
   {% endif %}
 <p style="margin: 0 0 0 0; line-height: 1em;">
   Browse by prefix: &ensp;
-  {{ macros.render_packages_prefixes(packages_prefixes) }}
+  {{ macros.render_packages_prefixes(packages_prefixes, request) }}
   &ensp; | &ensp;
   Browse <a href="{{ url_for(endpoint, page=1) }}">by page</a>
 </p>

--- a/debsources/tests/test_web_patches.py
+++ b/debsources/tests/test_web_patches.py
@@ -20,7 +20,7 @@ from debsources.tests.test_webapp import DebsourcesBaseWebTests
 
 
 @attr('patches')
-class CopyrightTestCase(DebsourcesBaseWebTests, unittest.TestCase):
+class PatchesTestCase(DebsourcesBaseWebTests, unittest.TestCase):
 
     def test_api_ping(self):
         rv = json.loads(self.app.get('/patches/api/ping/').data)
@@ -120,8 +120,8 @@ class CopyrightTestCase(DebsourcesBaseWebTests, unittest.TestCase):
         self.assertIn('collected debian patches for gnubg', rv.data)
         # test long dsc
         rv = self.app.get('/patches/beignet/1.0.0-1/')
-        long_dsc = 'Turn on udebug so tests print their full output, and mark' \
-                   ' failures\nby &#34;failed:&#34; instead of invisible-in-' \
+        long_dsc = 'Turn on udebug so tests print their full output, and mark'\
+                   ' failures\nby &#34;failed:&#34; instead of invisible-in-'\
                    'logs colour.'
         self.assertIn(long_dsc, rv.data)
         # test no description header


### PR DESCRIPTION
On deployment the request object is not available to macros. So i am passing it to them

When including templates there shouldn't be a {% block %}
